### PR TITLE
Add FSDP to simple LLM PDF example

### DIFF
--- a/apps/deeplearning/simple_llm_pdf/README.md
+++ b/apps/deeplearning/simple_llm_pdf/README.md
@@ -1,0 +1,31 @@
+# Simple PDF LLM Example
+
+This example shows how to read a PDF file, tokenize its text and perform a basic computation with a small language model.
+The model is wrapped using PyTorch's **FSDP** (Fully Sharded Data Parallel).
+
+## Requirements
+
+Install the required Python packages. FSDP requires a PyTorch build with distributed support:
+
+```bash
+pip install PyPDF2 transformers torch
+```
+
+## Usage
+
+Pass the path to a PDF when running the script. By default it uses the `distilgpt2` model from HuggingFace.
+
+```bash
+python main.py --pdf ../../openlog/\데이터로거(OPENLOG)_Rev1.1.pdf
+```
+
+You can specify the process group backend with `--backend` (defaults to `gloo`).
+
+You can choose a different model with the `--model` option.
+
+The script prints:
+
+- Number of extracted characters from the PDF
+- Token count from the tokenizer
+- Model parameter count
+- Output tensor shape from a single forward pass

--- a/apps/deeplearning/simple_llm_pdf/main.py
+++ b/apps/deeplearning/simple_llm_pdf/main.py
@@ -1,0 +1,54 @@
+import argparse
+import PyPDF2
+from transformers import AutoTokenizer, AutoModelForCausalLM
+import torch
+import torch.distributed as dist
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+def read_pdf(path: str) -> str:
+    """Read text from a PDF file."""
+    text = ""
+    with open(path, "rb") as f:
+        reader = PyPDF2.PdfReader(f)
+        for page in reader.pages:
+            page_text = page.extract_text()
+            if page_text:
+                text += page_text + "\n"
+    return text
+
+def count_model_params(model) -> int:
+    """Return the number of parameters in the model."""
+    return sum(p.numel() for p in model.parameters())
+
+def main():
+    parser = argparse.ArgumentParser(description="PDF tokenization with LLM example")
+    parser.add_argument("--pdf", required=True, help="Path to input PDF")
+    parser.add_argument("--model", default="distilgpt2", help="HuggingFace model name")
+    parser.add_argument("--backend", default="gloo", help="Distributed backend for FSDP")
+    args = parser.parse_args()
+
+    dist.init_process_group(backend=args.backend, rank=0, world_size=1)
+
+    text = read_pdf(args.pdf)
+    if not text:
+        print("No text extracted from PDF")
+        return
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    tokens = tokenizer(text, return_tensors="pt")
+    print(f"Extracted {len(text)} characters")
+    print(f"Token count: {tokens.input_ids.shape[1]}")
+
+    model = AutoModelForCausalLM.from_pretrained(args.model)
+    fsdp_model = FSDP(model)
+    param_count = count_model_params(fsdp_model)
+    print(f"Model '{args.model}' parameter count: {param_count:,}")
+
+    with torch.no_grad():
+        outputs = fsdp_model(**tokens)
+    print(f"Output logits shape: {outputs.logits.shape}")
+
+    dist.destroy_process_group()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- wrap the example model with PyTorch Fully Sharded Data Parallel (FSDP)
- document how to run with an optional backend parameter

## Testing
- `python -m py_compile apps/deeplearning/simple_llm_pdf/main.py`


------
https://chatgpt.com/codex/tasks/task_e_685da8988d788331a00dbcb906f9d453