### PR TITLE
Improve JSON search interface

### DIFF
--- a/apps/self_data_analytics/json_streamlit.py
+++ b/apps/self_data_analytics/json_streamlit.py
@@ -1,24 +1,48 @@
 import streamlit as st
 import json
+import os
 
-# JSON 파일 열기
-uploaded_file = st.file_uploader("JSON 파일을 업로드하세요", type="json")
-if uploaded_file is not None:
-    data = json.load(uploaded_file)
-    st.write("JSON 데이터:", data)
-    print(isinstance(data, dict))
-    item_count = len(data)
-    st.write(f"JSON 아이템 갯수: {item_count}")
-    # 키워드 입력 (Streamlit 웹 화면에서 입력)
-    keyword = st.text_input("검색할 키워드를 입력하세요")
+# 기본 파일 이름 설정
+file_path = st.text_input("JSON 파일 경로", value="file_list.json")
 
-    if keyword:
-        if isinstance(data, dict):
-            results = {k: v for k, v in data.items() if keyword in k or keyword in str(v)}
-        elif isinstance(data, list):
-            results = [item for item in data if isinstance(item, dict) and any(
-                keyword in str(k) or keyword in str(v) for k, v in item.items())]
-        else:
-            results = "지원되지 않는 JSON 구조입니다."
+data = None
+if os.path.exists(file_path):
+    # 기본 파일이 존재하면 버튼 하나로 바로 열 수 있게 함
+    if st.button("오픈"):
+        try:
+            with open(file_path, "r") as f:
+                data = json.load(f)
+            st.session_state['json_string'] = json.dumps(data, indent=2, ensure_ascii=False)
+        except Exception as e:
+            st.error(f"파일을 열 수 없습니다: {e}")
+else:
+    st.warning(f"{file_path} 파일이 존재하지 않습니다. 다른 파일을 선택하세요.")
+    uploaded_file = st.file_uploader("JSON 파일을 업로드하세요", type="json")
+    if uploaded_file is not None:
+        try:
+            data = json.load(uploaded_file)
+            st.session_state['json_string'] = json.dumps(data, indent=2, ensure_ascii=False)
+        except Exception as e:
+            st.error(f"업로드된 파일을 읽을 수 없습니다: {e}")
 
-        st.write("검색 결과:", results)
+# 세션 상태에 저장된 JSON 문자열을 가져와서 편집 가능하도록 표시
+json_string = st.session_state.get('json_string', '')
+edited_json_string = st.text_area("JSON 데이터 편집", value=json_string, height=300)
+
+if edited_json_string:
+    try:
+        data = json.loads(edited_json_string)
+        item_count = len(data) if isinstance(data, (dict, list)) else 0
+        st.write(f"JSON 아이템 갯수: {item_count}")
+        # 키워드 입력
+        keyword = st.text_input("검색할 키워드를 입력하세요")
+        if keyword:
+            if isinstance(data, dict):
+                results = {k: v for k, v in data.items() if keyword in str(k) or keyword in str(v)}
+            elif isinstance(data, list):
+                results = [item for item in data if isinstance(item, dict) and any(keyword in str(k) or keyword in str(v) for k, v in item.items())]
+            else:
+                results = "지원되지 않는 JSON 구조입니다."
+            st.write("검색 결과:", results)
+    except json.JSONDecodeError as e:
+        st.error(f"JSON 구문 오류: {e}")


### PR DESCRIPTION
## Summary
- make the Streamlit JSON viewer editable
- add default filename `file_list.json` so pressing **오픈** loads it automatically
- open an upload dialog when the default file does not exist

## Testing
- `python -m py_compile apps/self_data_analytics/json_streamlit.py`


------
https://chatgpt.com/codex/tasks/task_e_686639e4e748833196a29b1f120a6a55