### PR TITLE
Add monthly SSL expiry notification script

### DIFF
--- a/setup/shell/monthly_ssl_expire_notice.sh
+++ b/setup/shell/monthly_ssl_expire_notice.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Author: https://github.com/jeonghoonkang
+# openssl 을 이용하여 HTTPS 인증서 만료일을 확인하고 telegram-send 로 전송
+# Usage: $0 <domain> [port]
+# Example crontab (매달 1일 오전 9시):
+# 0 9 1 * * bash /home/tinyos/devel/BerePi/setup/shell/monthly_ssl_expire_notice.sh example.com
+
+DOMAIN="$1"
+PORT="${2:-443}"
+if [ -z "$DOMAIN" ]; then
+    echo "Usage: $0 <domain> [port]" >&2
+    exit 1
+fi
+
+end_date=$(openssl s_client -servername "$DOMAIN" -connect "$DOMAIN:$PORT" 2>/dev/null \
+    | openssl x509 -noout -enddate | cut -d= -f2)
+
+if [ -z "$end_date" ]; then
+    echo "Failed to retrieve certificate for $DOMAIN" >&2
+    exit 2
+fi
+
+message="SSL certificate for $DOMAIN expires on $end_date"
+echo "$message" | telegram-send --stdin
+

--- a/system/readme.md
+++ b/system/readme.md
@@ -23,3 +23,8 @@
 ### sudo crontab
 - 부팅 초기에 주기적으로 실행해야 하는 코드는 아래처럼 실행
   - <pre> */3 * * * * bash /home/tinyos/devel/BerePi/system/init_file/sonno_start.sh `sudo vcgencmd measure_temp` > /home/tinyos/devel/BerePi/logs/berepi_sys_log.log 2>&1 </pre>
+
+### SSL 인증서 만기 알림
+- openssl 로 인증서 만기일을 조회해 telegram-send 로 전송하는 스크립트
+- 매달 1일 오전 9시에 실행하도록 설정 예시
+  - <pre>0 9 1 * * bash /home/tinyos/devel/BerePi/setup/shell/monthly_ssl_expire_notice.sh example.com > /dev/null 2>&1</pre>


### PR DESCRIPTION
## Summary
- add `monthly_ssl_expire_notice.sh` to send certificate expiry dates using telegram-send
- document crontab usage in `system/readme.md`

## Testing
- `bash -n setup/shell/monthly_ssl_expire_notice.sh`


------
https://chatgpt.com/codex/tasks/task_e_686c46b317e083319583823d45cd7b46