### PR TITLE
Add Streamlit demo for Qwen LLM

### DIFF
--- a/apps/deeplearning/qwen_streamlit/README.md
+++ b/apps/deeplearning/qwen_streamlit/README.md
@@ -1,0 +1,21 @@
+# Qwen Streamlit Demo
+
+This example shows how to build a simple chat interface using [Streamlit](https://streamlit.io/) and the Qwen language model from HuggingFace.
+
+## Requirements
+
+Install the required Python packages:
+
+```bash
+pip install streamlit transformers torch
+```
+
+## Usage
+
+Run the Streamlit application:
+
+```bash
+streamlit run app.py
+```
+
+Enter a sentence in the text input box and the model will generate a response.

--- a/apps/deeplearning/qwen_streamlit/app.py
+++ b/apps/deeplearning/qwen_streamlit/app.py
@@ -1,0 +1,35 @@
+import streamlit as st
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+
+def load_model(model_name: str):
+    """Load the tokenizer and model."""
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model.to(device)
+    return tokenizer, model, device
+
+
+def generate_response(prompt: str, tokenizer, model, device):
+    """Generate text from the model given a prompt."""
+    inputs = tokenizer(prompt, return_tensors="pt").to(device)
+    with torch.no_grad():
+        outputs = model.generate(**inputs, max_new_tokens=128)
+    return tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+
+st.title("Qwen Chat")
+model_name = "Qwen/Qwen1.5-0.5B-Chat"
+
+@st.cache_resource
+def get_model():
+    return load_model(model_name)
+
+
+prompt = st.text_input("Enter a sentence")
+if prompt:
+    tokenizer, model, device = get_model()
+    response = generate_response(prompt, tokenizer, model, device)
+    st.write(response)


### PR DESCRIPTION
## Summary
- create a new demo using the Qwen language model and Streamlit
- show how to install requirements and run the app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytesseract', torch, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_686c8a2842ac8331b5d68d50e0e1586a