### PR TITLE
Add Python reverse proxy server

### DIFF
--- a/apps/webserver/reverse_proxy/README.md
+++ b/apps/webserver/reverse_proxy/README.md
@@ -1,0 +1,22 @@
+# Multi Reverse Proxy
+
+이 스크립트는 간단한 파이썬 기반 리버스 프록시 서버입니다. 여러 개의 내부 웹 서비스를
+각각 다른 외부 포트로 포워딩할 수 있습니다.
+
+## 사용법
+
+```
+python3 multi_reverse_proxy.py --map OUT_PORT:HOST:PORT [--map OUT_PORT:HOST:PORT ...]
+```
+
+예를 들어 내부의 `localhost:5000` 서비스를 외부 8080 포트로,
+`localhost:5001` 서비스를 8081 포트로 노출하려면 다음과 같이 실행합니다.
+
+```
+python3 multi_reverse_proxy.py \
+    --map 8080:localhost:5000 \
+    --map 8081:localhost:5001
+```
+
+실행하면 각 매핑에 대해 "Forwarding" 메시지가 표시되며, 여러 프록시가 동시에 동작합니다.
+종료하려면 `Ctrl+C` 를 누르면 됩니다.

--- a/apps/webserver/reverse_proxy/multi_reverse_proxy.py
+++ b/apps/webserver/reverse_proxy/multi_reverse_proxy.py
@@ -1,0 +1,98 @@
+import argparse
+import http.server
+import socketserver
+import urllib.request
+import urllib.parse
+import threading
+
+class ProxyHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+    def do_GET(self):
+        self.forward()
+
+    def do_POST(self):
+        self.forward()
+
+    def do_PUT(self):
+        self.forward()
+
+    def do_DELETE(self):
+        self.forward()
+
+    def do_HEAD(self):
+        self.forward()
+
+    def forward(self):
+        target = self.server.target
+        url = urllib.parse.urljoin(target, self.path)
+        data = None
+        if 'Content-Length' in self.headers:
+            length = int(self.headers['Content-Length'])
+            data = self.rfile.read(length)
+        headers = {k: v for k, v in self.headers.items() if k.lower() != 'host'}
+        req = urllib.request.Request(url, data=data, headers=headers, method=self.command)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                self.send_response(resp.status)
+                for key, value in resp.getheaders():
+                    if key.lower() == 'transfer-encoding' and value.lower() == 'chunked':
+                        continue
+                    self.send_header(key, value)
+                self.end_headers()
+                body = resp.read()
+                self.wfile.write(body)
+        except urllib.error.HTTPError as e:
+            self.send_error(e.code, e.reason)
+        except Exception as e:
+            self.send_error(502, str(e))
+
+class ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+
+
+def start_proxy(port, target):
+    handler = ProxyHTTPRequestHandler
+    server = ThreadingHTTPServer(('', port), handler)
+    server.target = target
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def parse_map(mapping):
+    parts = mapping.split(':')
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError('mapping must be OUT_PORT:HOST:PORT')
+    out_port = int(parts[0])
+    host = parts[1]
+    target_port = int(parts[2])
+    target = f'http://{host}:{target_port}'
+    return out_port, target
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Simple multi reverse proxy')
+    parser.add_argument('--map', action='append', required=True,
+                        metavar='OUT_PORT:HOST:PORT',
+                        help='forward OUT_PORT to HOST:PORT')
+    args = parser.parse_args()
+
+    servers = []
+    for m in args.map:
+        out_port, target = parse_map(m)
+        srv = start_proxy(out_port, target)
+        print(f'Forwarding 0.0.0.0:{out_port} -> {target}')
+        servers.append(srv)
+
+    try:
+        threading.Event().wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        for srv in servers:
+            srv.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement a simple multi reverse proxy server using Python standard library
- document how to use the new proxy script

## Testing
- `python -c "import aiohttp, sys; print('aiohttp', aiohttp.__version__)"` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686c8def20ec833187b3e2e7247995ab