### PR TITLE
Add login prompt for proxy status page

### DIFF
--- a/apps/webserver/reverse_proxy/README.md
+++ b/apps/webserver/reverse_proxy/README.md
@@ -1,0 +1,30 @@
+# Multi Reverse Proxy
+
+이 스크립트는 간단한 파이썬 기반 리버스 프록시 서버입니다. 여러 개의 내부 웹 서비스를
+각각 다른 외부 포트로 포워딩할 수 있습니다.
+
+## 사용법
+
+```
+python3 multi_reverse_proxy.py --map OUT_PORT:HOST:PORT [--map OUT_PORT:HOST:PORT ...]
+```
+
+예를 들어 내부의 `localhost:5000` 서비스를 외부 8080 포트로,
+`localhost:5001` 서비스를 8081 포트로 노출하려면 다음과 같이 실행합니다.
+
+```
+python3 multi_reverse_proxy.py \
+    --map 8080:localhost:5000 \
+    --map 8081:localhost:5001
+    --status-port 9000
+    --status-user admin --status-pass secret
+```
+
+실행하면 각 매핑에 대해 "Forwarding" 메시지가 표시되며, 여러 프록시가 동시에 동작합니다.
+종료하려면 `Ctrl+C` 를 누르면 됩니다.
+
+기본적으로 상태 정보는 `status.txt` 파일에 저장됩니다. 첫 줄에는 상태 페이지가 동작하는
+포트 번호가 기록되며, 이후 줄에는 각 포트 매핑이 나열됩니다. 같은 정보는 `--status-port`
+옵션으로 지정한 포트에서 제공되는 웹 페이지에서도 확인할 수 있습니다.
+
+`--status-user` 와 `--status-pass` 옵션을 함께 지정하면 상태 페이지는 HTTP Basic 인증을 요구합니다. 브라우저에서 접속하면 401 응답과 함께 인증 팝업이 뜨므로, 미리 지정한 사용자 이름과 비밀번호를 입력하면 됩니다.

--- a/apps/webserver/reverse_proxy/multi_reverse_proxy.py
+++ b/apps/webserver/reverse_proxy/multi_reverse_proxy.py
@@ -1,0 +1,167 @@
+import argparse
+import base64
+import http.server
+import socketserver
+import urllib.request
+import urllib.parse
+import threading
+
+# hold mapping information (out_port -> target url) for status display
+status_data = []
+
+class ProxyHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+    def do_GET(self):
+        self.forward()
+
+    def do_POST(self):
+        self.forward()
+
+    def do_PUT(self):
+        self.forward()
+
+    def do_DELETE(self):
+        self.forward()
+
+    def do_HEAD(self):
+        self.forward()
+
+    def forward(self):
+        target = self.server.target
+        url = urllib.parse.urljoin(target, self.path)
+        data = None
+        if 'Content-Length' in self.headers:
+            length = int(self.headers['Content-Length'])
+            data = self.rfile.read(length)
+        headers = {k: v for k, v in self.headers.items() if k.lower() != 'host'}
+        req = urllib.request.Request(url, data=data, headers=headers, method=self.command)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                self.send_response(resp.status)
+                for key, value in resp.getheaders():
+                    if key.lower() == 'transfer-encoding' and value.lower() == 'chunked':
+                        continue
+                    self.send_header(key, value)
+                self.end_headers()
+                body = resp.read()
+                self.wfile.write(body)
+        except urllib.error.HTTPError as e:
+            self.send_error(e.code, e.reason)
+        except Exception as e:
+            self.send_error(502, str(e))
+
+class ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+
+
+class StatusHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        # Basic authentication if configured
+        expected = getattr(self.server, 'auth', None)
+        if expected:
+            auth_header = self.headers.get('Authorization')
+            if auth_header != expected:
+                self.send_response(401)
+                self.send_header('WWW-Authenticate', 'Basic realm="Proxy Status"')
+                self.send_header('Content-Type', 'text/plain; charset=utf-8')
+                self.end_headers()
+                self.wfile.write(b'Authentication required.')
+                return
+        html = '<html><body><h1>Proxy Status</h1>'
+        html += f'<p>Status port: {self.server.status_port}</p>'
+        html += '<ul>'
+        for out_port, target in self.server.data:
+            html += f'<li>{out_port} -&gt; {target}</li>'
+        html += '</ul></body></html>'
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.end_headers()
+        self.wfile.write(html.encode('utf-8'))
+
+
+def start_status_server(port, data, auth_header=None):
+    handler = StatusHTTPRequestHandler
+    server = ThreadingHTTPServer(('', port), handler)
+    server.data = data
+    server.status_port = port
+    if auth_header:
+        server.auth = auth_header
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def write_status_file(path, data, status_port):
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(f'status_port: {status_port}\n')
+        for out_port, target in data:
+            f.write(f'{out_port} -> {target}\n')
+
+
+def start_proxy(port, target):
+    handler = ProxyHTTPRequestHandler
+    server = ThreadingHTTPServer(('', port), handler)
+    server.target = target
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def parse_map(mapping):
+    parts = mapping.split(':')
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError('mapping must be OUT_PORT:HOST:PORT')
+    out_port = int(parts[0])
+    host = parts[1]
+    target_port = int(parts[2])
+    target = f'http://{host}:{target_port}'
+    return out_port, target
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Simple multi reverse proxy')
+    parser.add_argument('--map', action='append', required=True,
+                        metavar='OUT_PORT:HOST:PORT',
+                        help='forward OUT_PORT to HOST:PORT')
+    parser.add_argument('--status-port', type=int, default=8000,
+                        help='port to serve status page')
+    parser.add_argument('--status-file', default='status.txt',
+                        help='path to write status information')
+    parser.add_argument('--status-user', default=None,
+                        help='username for status page basic auth')
+    parser.add_argument('--status-pass', dest='status_pass', default=None,
+                        help='password for status page basic auth')
+    args = parser.parse_args()
+
+    servers = []
+    global status_data
+    for m in args.map:
+        out_port, target = parse_map(m)
+        srv = start_proxy(out_port, target)
+        print(f'Forwarding 0.0.0.0:{out_port} -> {target}')
+        servers.append(srv)
+        status_data.append((out_port, target))
+
+    write_status_file(args.status_file, status_data, args.status_port)
+
+    auth_header = None
+    if args.status_user and args.status_pass:
+        token = f'{args.status_user}:{args.status_pass}'
+        b64 = base64.b64encode(token.encode('utf-8')).decode('ascii')
+        auth_header = 'Basic ' + b64
+
+    status_srv = start_status_server(args.status_port, status_data, auth_header)
+
+    try:
+        threading.Event().wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        status_srv.shutdown()
+        for srv in servers:
+            srv.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- clarify in README that a browser will receive a 401 response and show an auth popup
- return a short message with the 401 response to ensure browsers present the login dialog

## Testing
- `python3 -m py_compile apps/webserver/reverse_proxy/multi_reverse_proxy.py`
- `python3 apps/webserver/reverse_proxy/multi_reverse_proxy.py --help | head`
- `curl -i http://localhost:9002` (shows 401 response)


------
https://chatgpt.com/codex/tasks/task_e_686c8def20ec833187b3e2e7247995ab