### PR TITLE
Fix login redirect URL

### DIFF
--- a/apps/webserver/reverse_proxy/README.md
+++ b/apps/webserver/reverse_proxy/README.md
@@ -1,0 +1,33 @@
+# Multi Reverse Proxy
+
+이 스크립트는 간단한 파이썬 기반 리버스 프록시 서버입니다. 여러 개의 내부 웹 서비스를
+각각 다른 외부 포트로 포워딩할 수 있습니다.
+
+## 사용법
+
+```
+python3 multi_reverse_proxy.py --map OUT_PORT:HOST:PORT [--map OUT_PORT:HOST:PORT ...]
+```
+
+예를 들어 내부의 `localhost:5000` 서비스를 외부 8080 포트로,
+`localhost:5001` 서비스를 8081 포트로 노출하려면 다음과 같이 실행합니다.
+
+```
+python3 multi_reverse_proxy.py \
+    --map 8080:localhost:5000 \
+    --map 8081:localhost:5001
+    --status-port 9000
+    --status-user admin --status-pass secret
+    --redirect-port 2281
+```
+
+실행하면 각 매핑에 대해 "Forwarding" 메시지가 표시되며, 여러 프록시가 동시에 동작합니다.
+종료하려면 `Ctrl+C` 를 누르면 됩니다.
+
+기본적으로 상태 정보는 `status.txt` 파일에 저장됩니다. 첫 줄에는 상태 페이지가 동작하는
+포트 번호가 기록되며, 이후 줄에는 각 포트 매핑이 나열됩니다. 같은 정보는 `--status-port`
+옵션으로 지정한 포트에서 제공되는 웹 페이지에서도 확인할 수 있습니다.
+
+`--status-user` 와 `--status-pass` 옵션을 함께 지정하면 상태 페이지에 접속했을 때 사용자 이름과 비밀번호를 입력할 수 있는 간단한 로그인 화면이 나타납니다. 올바른 값을 입력하면 현재 프록시 상태 정보를 볼 수 있습니다.
+
+로그인 성공 후에는 `http://bigsoft.iptime.org`의 `--redirect-port` 값으로 설정된 포트로 리다이렉트됩니다.

--- a/apps/webserver/reverse_proxy/multi_reverse_proxy.py
+++ b/apps/webserver/reverse_proxy/multi_reverse_proxy.py
@@ -1,0 +1,215 @@
+import argparse
+import http.server
+import socketserver
+import urllib.request
+import urllib.parse
+import threading
+
+# hold mapping information (out_port -> target url) for status display
+status_data = []
+
+class ProxyHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+    def do_GET(self):
+        self.forward()
+
+    def do_POST(self):
+        self.forward()
+
+    def do_PUT(self):
+        self.forward()
+
+    def do_DELETE(self):
+        self.forward()
+
+    def do_HEAD(self):
+        self.forward()
+
+    def forward(self):
+        target = self.server.target
+        url = urllib.parse.urljoin(target, self.path)
+        data = None
+        if 'Content-Length' in self.headers:
+            length = int(self.headers['Content-Length'])
+            data = self.rfile.read(length)
+        headers = {k: v for k, v in self.headers.items() if k.lower() != 'host'}
+        req = urllib.request.Request(url, data=data, headers=headers, method=self.command)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                self.send_response(resp.status)
+                for key, value in resp.getheaders():
+                    if key.lower() == 'transfer-encoding' and value.lower() == 'chunked':
+                        continue
+                    self.send_header(key, value)
+                self.end_headers()
+                body = resp.read()
+                self.wfile.write(body)
+        except urllib.error.HTTPError as e:
+            self.send_error(e.code, e.reason)
+        except Exception as e:
+            self.send_error(502, str(e))
+
+class ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+
+
+class StatusHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+    def _show_login(self, invalid=False):
+        html = '<html><body><h1>Login</h1>'
+        if invalid:
+            html += '<p style="color:red">Invalid credentials</p>'
+        html += (
+            '<form method="post" action="/login">'
+            'Username: <input type="text" name="username"><br>'
+            'Password: <input type="password" name="password"><br>'
+            '<input type="submit" value="Login">'
+            '</form></body></html>'
+        )
+        body = html.encode('utf-8')
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _show_status(self):
+        html = '<html><body><h1>Proxy Status</h1>'
+        html += f'<p>Status port: {self.server.status_port}</p>'
+        html += '<ul>'
+        for out_port, target in self.server.data:
+            html += f'<li>{out_port} -&gt; {target}</li>'
+        html += '</ul></body></html>'
+        body = html.encode('utf-8')
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if getattr(self.server, 'requires_auth', False):
+            cookie = self.headers.get('Cookie', '')
+            if 'auth=1' not in cookie:
+                self._show_login()
+                return
+        self._show_status()
+
+    def do_POST(self):
+        if self.path == '/login' and getattr(self.server, 'requires_auth', False):
+            length = int(self.headers.get('Content-Length', '0'))
+            body = self.rfile.read(length).decode('utf-8')
+            params = urllib.parse.parse_qs(body)
+            user = params.get('username', [''])[0]
+            pw = params.get('password', [''])[0]
+            if user == self.server.auth_user and pw == self.server.auth_pass:
+                # After successful login redirect the browser to the
+                # external address which is also stored in the cookie
+                port = getattr(self.server, 'redirect_port', 2281)
+                redirect_url = f'http://bigsoft.iptime.org:{port}'
+                self.send_response(303)
+                self.send_header('Set-Cookie', 'auth=1; Path=/')
+                self.send_header('Location', redirect_url)
+                self.send_header('Content-Length', '0')
+                self.end_headers()
+                return
+            else:
+                self._show_login(invalid=True)
+        else:
+            self.send_error(404)
+
+
+def start_status_server(port, data, auth_user=None, auth_pass=None, redirect_port=2281):
+    handler = StatusHTTPRequestHandler
+    server = ThreadingHTTPServer(('', port), handler)
+    server.data = data
+    server.status_port = port
+    server.redirect_port = redirect_port
+    if auth_user and auth_pass:
+        server.auth_user = auth_user
+        server.auth_pass = auth_pass
+        server.requires_auth = True
+    else:
+        server.requires_auth = False
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def write_status_file(path, data, status_port):
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(f'status_port: {status_port}\n')
+        for out_port, target in data:
+            f.write(f'{out_port} -> {target}\n')
+
+
+def start_proxy(port, target):
+    handler = ProxyHTTPRequestHandler
+    server = ThreadingHTTPServer(('', port), handler)
+    server.target = target
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def parse_map(mapping):
+    parts = mapping.split(':')
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError('mapping must be OUT_PORT:HOST:PORT')
+    out_port = int(parts[0])
+    host = parts[1]
+    target_port = int(parts[2])
+    target = f'http://{host}:{target_port}'
+    return out_port, target
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Simple multi reverse proxy')
+    parser.add_argument('--map', action='append', required=True,
+                        metavar='OUT_PORT:HOST:PORT',
+                        help='forward OUT_PORT to HOST:PORT')
+    parser.add_argument('--status-port', type=int, default=8000,
+                        help='port to serve status page')
+    parser.add_argument('--status-file', default='status.txt',
+                        help='path to write status information')
+    parser.add_argument('--status-user', default=None,
+                        help='username for status page basic auth')
+    parser.add_argument('--status-pass', dest='status_pass', default=None,
+                        help='password for status page basic auth')
+    parser.add_argument('--redirect-port', type=int, default=2281,
+                        help='port used to build login redirect URL')
+    args = parser.parse_args()
+
+    servers = []
+    global status_data
+    for m in args.map:
+        out_port, target = parse_map(m)
+        srv = start_proxy(out_port, target)
+        print(f'Forwarding 0.0.0.0:{out_port} -> {target}')
+        servers.append(srv)
+        status_data.append((out_port, target))
+
+    write_status_file(args.status_file, status_data, args.status_port)
+
+    status_srv = start_status_server(
+        args.status_port,
+        status_data,
+        auth_user=args.status_user,
+        auth_pass=args.status_pass,
+        redirect_port=args.redirect_port,
+    )
+
+    try:
+        threading.Event().wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        status_srv.shutdown()
+        for srv in servers:
+            srv.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- update StatusHTTPRequestHandler so successful login redirects to user-specified port
- allow setting redirect port via `--redirect-port` argument
- document redirect behavior in README

## Testing
- `python3 -m py_compile apps/webserver/reverse_proxy/multi_reverse_proxy.py`
- `python3 apps/webserver/reverse_proxy/multi_reverse_proxy.py --help`

------
https://chatgpt.com/codex/tasks/task_e_686c8def20ec833187b3e2e7247995ab