### PR TITLE
Add status reader with password prompt

### DIFF
--- a/apps/webserver/reverse_proxy/README.md
+++ b/apps/webserver/reverse_proxy/README.md
@@ -52,3 +52,15 @@ print(f"[1] POST to {login_url}")
 response = session.post(login_url, data=login_data, allow_redirects=False)
 ```
 
+### status.txt 조회 스크립트
+
+`status_reader.py` 스크립트는 로컬에 저장된 `status.txt` 파일을
+비밀번호 입력 후 확인할 수 있게 해 줍니다.
+
+```bash
+python3 status_reader.py --file status.txt --expected-pass secret
+```
+
+비밀번호가 올바르면 파일 내용을 출력하고, 틀리면 `Access denied` 메시지가
+표시됩니다.
+

--- a/apps/webserver/reverse_proxy/status_reader.py
+++ b/apps/webserver/reverse_proxy/status_reader.py
@@ -1,0 +1,32 @@
+import argparse
+import getpass
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Show status file content with a password prompt"
+    )
+    parser.add_argument("--file", default="status.txt", help="path to status file")
+    parser.add_argument(
+        "--expected-pass",
+        default="secret",
+        help="password required to view the file",
+    )
+    args = parser.parse_args()
+
+    entered = getpass.getpass("Password: ")
+    if entered != args.expected_pass:
+        print("Access denied")
+        sys.exit(1)
+
+    try:
+        with open(args.file, "r", encoding="utf-8") as f:
+            print(f.read())
+    except FileNotFoundError:
+        print(f"File not found: {args.file}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small script `status_reader.py` to display `status.txt` after password verification
- document how to use the new script in the reverse proxy README

## Testing
- `python3 -m py_compile apps/webserver/reverse_proxy/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686d77e3faa88331b8de6d659105bdc0