### PR TITLE
Add Streamlit app using Llama 3

### DIFF
--- a/apps/llama3_tour_qa/README.md
+++ b/apps/llama3_tour_qa/README.md
@@ -1,0 +1,18 @@
+# Korean Tourism Q&A with Llama 3
+
+This Streamlit app uses Meta's Llama 3 model to answer questions about travel in Korea.
+
+## Usage
+
+1. Install requirements:
+   ```bash
+   pip install streamlit transformers
+   ```
+   You also need a local copy of the Llama 3 model. Set the environment variable `LLAMA3_MODEL` to the directory or model name.
+2. Run the app:
+   ```bash
+   streamlit run app.py
+   ```
+
+By default the app loads `meta-llama/Meta-Llama-3-8B-Instruct` from HuggingFace.
+Set `LLAMA3_MODEL` if you want to use a local path or a different model.

--- a/apps/llama3_tour_qa/app.py
+++ b/apps/llama3_tour_qa/app.py
@@ -1,0 +1,25 @@
+import os
+import streamlit as st
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+st.set_page_config(page_title="Korean Tourism Q&A", page_icon="\ud83c\udf0d")
+
+st.title("\ud83c\uddf0\ud83c\uddf7 Korean Tourism Q&A with Llama 3")
+
+# Load model only once
+@st.cache_resource
+def load_model():
+    model_name = os.environ.get("LLAMA3_MODEL", "meta-llama/Meta-Llama-3-8B-Instruct")
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    generator = pipeline("text-generation", model=model, tokenizer=tokenizer)
+    return generator
+
+generator = load_model()
+
+prompt = st.text_input("Ask about tourism in Korea:")
+if prompt:
+    with st.spinner("Generating answer..."):
+        # We limit max length to keep response quick
+        response = generator(prompt, max_length=512, do_sample=True)
+        st.write(response[0]["generated_text"][len(prompt):].strip())


### PR DESCRIPTION
## Summary
- add new Streamlit example `apps/llama3_tour_qa` for a Korean tourism Q&A demo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_686e21679f5883318b559796d1bc904b