### PR TITLE
Add local port 1001 mapping to SSH service

### DIFF
--- a/setup/ssh/readme.md
+++ b/setup/ssh/readme.md
@@ -64,3 +64,11 @@ The key's randomart image is:
   - .ssh 는 700
   - authorized_keys 는 600
       
+
+### Using an additional local port for SSH
+- Local port `1001` can be mapped to the default SSH port `22`.
+- Run `redirect_1001_to_22.sh` as root to add the port forwarding rule:
+  ```bash
+  sudo ./redirect_1001_to_22.sh
+  ```
+- After executing, connections to port `1001` will be served by the same SSH daemon running on port `22`.

--- a/setup/ssh/redirect_1001_to_22.sh
+++ b/setup/ssh/redirect_1001_to_22.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Redirect incoming connections on port 1001 to the local SSH service (port 22)
+# Run this script with root privileges.
+
+iptables -t nat -A PREROUTING -p tcp --dport 1001 -j REDIRECT --to-port 22
+iptables -t nat -A OUTPUT -p tcp --dport 1001 -j REDIRECT --to-port 22


### PR DESCRIPTION
## Summary
- add script `redirect_1001_to_22.sh` to redirect port 1001 to port 22 via iptables
- document how to use this script in `setup/ssh/readme.md`

## Testing
- `bash -n setup/ssh/redirect_1001_to_22.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e1298981c83319268d7f3bf5ef531