### PR TITLE
Fix rerun compatibility

### DIFF
--- a/apps/llama3_tour_qa/README.md
+++ b/apps/llama3_tour_qa/README.md
@@ -1,0 +1,19 @@
+# Llama 3로 한국 관광 Q&A
+
+이 Streamlit 앱은 Meta의 Llama 3 모델을 사용하여 한국 여행에 관한 질문에 답합니다.
+
+## 사용 방법
+
+1. 필요한 패키지 설치
+   ```bash
+   pip install streamlit transformers huggingface_hub
+   ```
+   로컬에 Llama 3 모델 파일이 필요합니다. 환경 변수 `LLAMA3_MODEL`에 모델 폴더나 이름을 지정하세요.
+2. 앱 실행
+   ```bash
+   streamlit run app.py
+   ```
+
+기본값으로 HuggingFace의 `meta-llama/Meta-Llama-3-8B-Instruct`를 불러옵니다.
+모델 파일이 없으면 다운로드 여부를 묻고 10초 후 자동으로 다운로드를 시작하며,
+진행 상황을 프로그레스 바로 표시합니다. 앱 시작 시 GPU 사용 가능 여부도 출력합니다.

--- a/apps/llama3_tour_qa/app.py
+++ b/apps/llama3_tour_qa/app.py
@@ -1,0 +1,119 @@
+import os
+import time
+import threading
+
+import streamlit as st
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+
+def rerun() -> None:
+    """Compatibility helper to rerun the Streamlit script."""
+    if hasattr(st, "experimental_rerun"):
+        st.experimental_rerun()
+    else:
+        st.rerun()
+
+
+def display_gpu_status() -> None:
+    """Display current GPU status at startup."""
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            gpus = [f"{i}: {torch.cuda.get_device_name(i)}" for i in range(torch.cuda.device_count())]
+            st.info("GPU available: " + ", ".join(gpus))
+        else:
+            st.info("GPU not available, using CPU")
+    except Exception as exc:
+        st.warning(f"Could not determine GPU status: {exc}")
+
+st.set_page_config(page_title="Korean Tourism Q&A", page_icon="\ud83c\udf0d")
+
+st.title("\ud83c\uddf0\ud83c\uddf7 Korean Tourism Q&A with Llama 3")
+display_gpu_status()
+
+
+def download_model(model_name: str) -> None:
+    """Download the model showing a simple progress bar."""
+    try:
+        from huggingface_hub import snapshot_download
+    except Exception:
+        st.error("huggingface_hub is required to download models")
+        st.stop()
+
+    progress = st.progress(0)
+
+    def _download():
+        snapshot_download(repo_id=model_name, local_dir=model_name, resume_download=True)
+
+    thread = threading.Thread(target=_download)
+    thread.start()
+    pct = 0
+    while thread.is_alive():
+        pct = min(100, pct + 1)
+        progress.progress(pct / 100.0)
+        time.sleep(1)
+    progress.progress(1.0)
+    st.success("Download complete")
+
+
+def ensure_model(model_name: str) -> None:
+    """Ensure the model files are available. Auto download after 10s."""
+    if os.path.isdir(model_name):
+        return
+    try:
+        from huggingface_hub import hf_hub_download
+
+        hf_hub_download(repo_id=model_name, filename="config.json", local_files_only=True)
+        return
+    except Exception:
+        pass
+
+    if "prompt_time" not in st.session_state:
+        st.session_state.prompt_time = time.time()
+
+    elapsed = time.time() - st.session_state.prompt_time
+    remaining = int(10 - elapsed)
+
+    if "download_decision" not in st.session_state:
+        st.session_state.download_decision = None
+
+    if st.session_state.download_decision is None:
+        st.warning(f"Model '{model_name}' not found. Download? (auto in {max(remaining,0)}s)")
+        cols = st.columns(2)
+        if cols[0].button("Download now"):
+            st.session_state.download_decision = True
+            rerun()
+        if cols[1].button("Cancel"):
+            st.session_state.download_decision = False
+            st.stop()
+        if remaining <= 0:
+            st.session_state.download_decision = True
+            rerun()
+        else:
+            time.sleep(1)
+            rerun()
+    elif st.session_state.download_decision:
+        download_model(model_name)
+    else:
+        st.stop()
+
+MODEL_NAME = os.environ.get("LLAMA3_MODEL", "meta-llama/Meta-Llama-3-8B-Instruct")
+ensure_model(MODEL_NAME)
+
+# Load model only once
+@st.cache_resource
+def load_model(name: str):
+    tokenizer = AutoTokenizer.from_pretrained(name)
+    model = AutoModelForCausalLM.from_pretrained(name)
+    generator = pipeline("text-generation", model=model, tokenizer=tokenizer)
+    return generator
+
+generator = load_model(MODEL_NAME)
+
+prompt = st.text_input("Ask about tourism in Korea:")
+if prompt:
+    with st.spinner("Generating answer..."):
+        # We limit max length to keep response quick
+        response = generator(prompt, max_length=512, do_sample=True)
+        st.write(response[0]["generated_text"][len(prompt):].strip())


### PR DESCRIPTION
## Summary
- fix AttributeError by providing a helper to call `st.experimental_rerun` or `st.rerun`
- use the helper wherever a rerun was needed when downloading the model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686e21679f5883318b559796d1bc904b