### PR TITLE
Add Llama tool calling example

### DIFF
--- a/apps/llama_tool_calling/README.md
+++ b/apps/llama_tool_calling/README.md
@@ -1,0 +1,20 @@
+# Llama Tool Calling Example
+
+이 예제는 `llama-cpp-python` 라이브러리를 사용하여 Llama 모델과 함수 호출 기능(Function Calling)을 연동하는 간단한 CLI 프로그램입니다. 
+사용자는 대화 중에 명령을 내리면 LLM이 적절한 툴(함수)을 선택하여 실행하고, 그 결과를 바탕으로 다시 응답합니다.
+
+## 필요 패키지
+
+```bash
+pip install llama-cpp-python
+```
+
+## 실행 방법
+
+모델 경로를 지정하여 실행합니다. 예시 모델은 gguf 형식의 Llama 모델 파일입니다.
+
+```bash
+python app.py --model path/to/model.gguf
+```
+
+프로그램이 실행되면 프롬프트에 질문을 입력하고, "현재 시간 알려줘" 또는 "2+2 계산해"와 같이 명령을 내리면 툴이 실행됩니다.

--- a/apps/llama_tool_calling/app.py
+++ b/apps/llama_tool_calling/app.py
@@ -1,0 +1,103 @@
+import argparse
+import json
+import time
+from typing import Any, Dict, List
+
+from llama_cpp import Llama
+
+
+# ----- Tool functions -----
+
+def get_time() -> str:
+    """Return the current system time as a string."""
+    return time.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def calculate(expression: str) -> str:
+    """Evaluate a simple Python expression and return the result."""
+    try:
+        return str(eval(expression, {"__builtins__": {}}))
+    except Exception as exc:
+        return f"Error: {exc}"
+
+
+TOOLS = {
+    "get_time": get_time,
+    "calculate": calculate,
+}
+
+FUNCTION_DEFS = [
+    {
+        "name": "get_time",
+        "description": "현재 시간을 문자열로 반환합니다.",
+        "parameters": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "calculate",
+        "description": "주어진 수식을 계산합니다.",
+        "parameters": {
+            "type": "object",
+            "properties": {"expression": {"type": "string"}},
+            "required": ["expression"],
+        },
+    },
+]
+
+
+# ----- Main chat loop -----
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Llama function calling demo")
+    parser.add_argument("--model", required=True, help="Path to Llama gguf model")
+    parser.add_argument(
+        "--n_ctx", type=int, default=2048, help="Context window size"
+    )
+    args = parser.parse_args()
+
+    llm = Llama(model_path=args.model, n_ctx=args.n_ctx)
+
+    messages: List[Dict[str, Any]] = [
+        {"role": "system", "content": "You are a helpful assistant."}
+    ]
+
+    print("Type 'exit' to quit.")
+    while True:
+        user = input("User: ")
+        if user.strip().lower() == "exit":
+            break
+
+        messages.append({"role": "user", "content": user})
+        result = llm.create_chat_completion(
+            messages=messages,
+            functions=FUNCTION_DEFS,
+            temperature=0.7,
+        )
+        message = result["choices"][0]["message"]
+
+        # If the model requests a function call, execute it and respond again
+        if "function_call" in message:
+            name = message["function_call"]["name"]
+            args_json = message["function_call"].get("arguments", "{}")
+            try:
+                func_args = json.loads(args_json)
+            except json.JSONDecodeError:
+                func_args = {}
+            func = TOOLS.get(name)
+            if func:
+                output = func(**func_args)
+                messages.append(
+                    {"role": "function", "name": name, "content": output}
+                )
+                followup = llm.create_chat_completion(messages=messages)
+                reply = followup["choices"][0]["message"]["content"]
+            else:
+                reply = f"Unknown function: {name}"
+        else:
+            reply = message.get("content", "")
+
+        messages.append({"role": "assistant", "content": reply})
+        print(f"Assistant: {reply}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `llama_tool_calling` example that shows how to use llama-cpp function calling
- document usage and dependencies in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687378ad33688331a21af64ecddad669