### PR TITLE
Add FSDP LLaMA fine-tuning example

### DIFF
--- a/apps/deeplearning/LLM/llama/finetune_fsdp.py
+++ b/apps/deeplearning/LLM/llama/finetune_fsdp.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Example of fine-tuning LLaMA with PyTorch FSDP on two GPUs.
+
+This script uses HuggingFace Transformers and the wikitext-2 dataset to
+illustrate how to enable FSDP training. It is intended for a workstation
+with 2 RTX 4090 GPUs.
+
+Run with:
+
+    torchrun --nproc_per_node=2 finetune_fsdp.py --model meta-llama/Llama-2-7b-hf
+"""
+
+import argparse
+
+from datasets import load_dataset
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    Trainer,
+    TrainingArguments,
+)
+
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fine-tune LLaMA using FSDP")
+    parser.add_argument(
+        "--model",
+        default="meta-llama/Llama-2-7b-hf",
+        help="Model checkpoint or HuggingFace repository",
+    )
+    parser.add_argument(
+        "--dataset",
+        default="wikitext",
+        help="HuggingFace dataset name",
+    )
+    parser.add_argument(
+        "--subset",
+        default="wikitext-2-raw-v1",
+        help="Subset name for the dataset",
+    )
+    parser.add_argument(
+        "--output_dir",
+        default="./llama_fsdp_output",
+        help="Directory for checkpoints",
+    )
+    parser.add_argument("--max_steps", type=int, default=10)
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model, use_fast=False)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model, torch_dtype="auto"
+    )
+
+    dataset = load_dataset(args.dataset, args.subset, split="train[:1%]")
+    dataset = dataset.map(
+        lambda b: tokenizer(b["text"]),
+        batched=True,
+        remove_columns=["text"],
+    )
+
+    train_args = TrainingArguments(
+        output_dir=args.output_dir,
+        per_device_train_batch_size=1,
+        gradient_accumulation_steps=4,
+        max_steps=args.max_steps,
+        logging_steps=1,
+        fsdp="full_shard auto_wrap",
+        fsdp_transformer_layer_cls_to_wrap="LlamaDecoderLayer",
+        save_total_limit=1,
+        save_steps=5,
+    )
+
+    trainer = Trainer(model=model, args=train_args, train_dataset=dataset)
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/deeplearning/LLM/llama/readme.md
+++ b/apps/deeplearning/LLM/llama/readme.md
@@ -61,3 +61,16 @@ Now available on Github
 Cybersecurity Eval
 The first and most comprehensive set of open source cybersecurity safety evals for LLMs. These benchmarks are based on industry guidance and standards (e.g. CWE & MITRE ATT&CK) and built in collaboration with our security subject matter experts.
 Now available on Github
+
+## FSDP Fine-Tuning Example
+
+`finetune_fsdp.py` demonstrates how to fine-tune a LLaMA model with PyTorch FSDP.
+It loads a small portion of the Wikitext dataset and can be run on two GPUs.
+
+```bash
+# Run with two GPUs
+torchrun --nproc_per_node=2 finetune_fsdp.py --model meta-llama/Llama-2-7b-hf
+```
+
+The script uses HuggingFace Transformers so you need a compatible PyTorch build
+with distributed support.


### PR DESCRIPTION
## Summary
- add `finetune_fsdp.py` for training LLaMA with FSDP on two GPUs
- document how to run the script in `llama/readme.md`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6874bffe20e08331b5b8caad60568c0e