### PR TITLE
Add manual FSDP fine tuning example

### DIFF
--- a/apps/deeplearning/LLM/llama/finetune_fsdp_manual.py
+++ b/apps/deeplearning/LLM/llama/finetune_fsdp_manual.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Minimal FSDP fine-tuning example using plain text files."""
+
+import argparse
+import os
+from datasets import load_dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM, default_data_collator
+import torch
+import torch.distributed as dist
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.utils.data import DataLoader
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manual FSDP fine-tuning example")
+    parser.add_argument("--model", default="meta-llama/Llama-2-7b-hf")
+    parser.add_argument("--data_files", required=True,
+                        help="Comma separated list of text files")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--lr", type=float, default=1e-5)
+    parser.add_argument("--output_dir", default="./llama_fsdp_output")
+    args = parser.parse_args()
+
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    device = torch.device(f"cuda:{rank}")
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model, use_fast=False)
+    model = AutoModelForCausalLM.from_pretrained(args.model, torch_dtype=torch.float16)
+    fsdp_model = FSDP(model.to(device))
+
+    files = [p.strip() for p in args.data_files.split(",")]
+    dataset = load_dataset("text", data_files=files, split="train")
+    tokenized = dataset.map(lambda b: tokenizer(b["text"]), batched=True, remove_columns=["text"])
+    dataloader = DataLoader(tokenized, batch_size=args.batch_size, shuffle=True,
+                            collate_fn=default_data_collator)
+
+    optim = torch.optim.AdamW(fsdp_model.parameters(), lr=args.lr)
+
+    fsdp_model.train()
+    for _ in range(args.epochs):
+        for batch in dataloader:
+            batch = {k: v.to(device) for k, v in batch.items()}
+            outputs = fsdp_model(**batch, labels=batch["input_ids"])
+            loss = outputs.loss
+            loss.backward()
+            optim.step()
+            optim.zero_grad()
+        if rank == 0:
+            print(f"Epoch done, loss: {loss.item():.4f}")
+
+    if rank == 0:
+        os.makedirs(args.output_dir, exist_ok=True)
+        fsdp_model.cpu()
+        fsdp_model.save_pretrained(args.output_dir)
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/deeplearning/LLM/llama/readme_kor.md
+++ b/apps/deeplearning/LLM/llama/readme_kor.md
@@ -1,0 +1,44 @@
+# FSDP를 이용한 LLaMA 파인튜닝 예제
+
+이 폴더에는 PyTorch의 **FSDP**(Fully Sharded Data Parallel) 기능을 사용하여 LLaMA 모델을 학습하는 스크립트가 들어 있습니다.
+
+## 필요 패키지
+
+파인튜닝을 위해서는 PyTorch, Transformers, Datasets 패키지가 필요하며 PyTorch는 분산 기능이 활성화된 빌드여야 합니다.
+
+```bash
+pip install torch transformers datasets
+```
+
+## Wikitext 데이터셋 예제
+
+`finetune_fsdp.py` 스크립트는 wikitext 데이터셋 일부를 사용해 두 개의 GPU에서 모델을 학습합니다.
+
+```bash
+torchrun --nproc_per_node=2 finetune_fsdp.py --model meta-llama/Llama-2-7b-hf
+```
+
+## 사용자 데이터로 학습하기
+
+`finetune_fsdp_custom.py`를 실행하면 준비한 텍스트 파일을 이용해 모델을 파인튜닝할 수 있습니다. 여러 파일은 쉼표로 구분하여 입력합니다.
+
+```bash
+torchrun --nproc_per_node=2 finetune_fsdp_custom.py \
+    --model meta-llama/Llama-2-7b-hf \
+    --data_files example1.txt,example2.txt
+```
+
+스크립트는 지정된 텍스트 파일을 로드해 토크나이즈한 뒤 FSDP 모드로 학습을 수행합니다. `--output_dir`와 `--max_steps` 옵션을 사용해 체크포인트 저장 위치와 학습 스텝 수를 조절할 수 있습니다.
+
+## 직접 FSDP 루프 사용하기
+
+`finetune_fsdp_manual.py` 스크립트는 파이토치의 FSDP API를 이용해 간단한 학습 루프를 구성한 예제입니다. 두 개 이상의 GPU에서 다음과 같이 실행합니다.
+
+```bash
+torchrun --nproc_per_node=2 finetune_fsdp_manual.py \
+    --model meta-llama/Llama-2-7b-hf \
+    --data_files mydata.txt --epochs 1
+```
+
+이 예제는 `torch.distributed`를 초기화한 뒤 모델을 `FullyShardedDataParallel` 로 감싸고, 입력 텍스트를 토큰화하여 기본적인 학습 루프를 수행합니다.
+


### PR DESCRIPTION
## Summary
- add a manual FSDP training script for LLaMA
- mention the new example in the Korean guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_687694d35a1483318dc1c0f3d067ce61