### PR TITLE
Enable expression parsing for stress test duration

### DIFF
--- a/apps/test_stress_rpi/README.md
+++ b/apps/test_stress_rpi/README.md
@@ -7,8 +7,12 @@ it shows a progress bar using the Rich package.
 ## Usage
 
 ```bash
-python3 stress_test.py
+python3 stress_test.py [duration]
 ```
+
+The optional `duration` argument sets how long the test runs in seconds. You can
+also use a simple multiplication expression, e.g. `60*20` to run the test for
+1200 seconds.
 
 Install the `rich` package before running the script:
 

--- a/apps/test_stress_rpi/stress_test.py
+++ b/apps/test_stress_rpi/stress_test.py
@@ -104,11 +104,30 @@ def main(duration=900):
     print(f"Disk write        : {write_mb:.2f} MB")
 
 
+def _parse_duration(arg: str) -> int:
+    """Return integer duration from CLI argument.
+
+    Supports a simple ``a*b*c`` style expression so users can pass
+    values like ``60*20``. Any invalid input will raise ``ValueError``.
+    """
+
+    if "*" in arg:
+        parts = arg.split("*")
+        result = 1
+        for p in parts:
+            p = p.strip()
+            if not p:
+                raise ValueError(f"Invalid duration segment: '{arg}'")
+            result *= int(p)
+        return result
+    return int(arg)
+
+
 if __name__ == "__main__":
     dur = 60
     if len(sys.argv) > 1:
         try:
-            dur = int(sys.argv[1])
+            dur = _parse_duration(sys.argv[1])
         except ValueError:
             print(f"Invalid duration '{sys.argv[1]}', using default {dur}s")
     try:


### PR DESCRIPTION
## Summary
- allow duration argument in stress_test.py to accept multiplication expressions
- document optional argument and expression usage in README

## Testing
- `python3 -m py_compile apps/test_stress_rpi/stress_test.py`

------
https://chatgpt.com/codex/tasks/task_e_687a52b220ac8331ba458804465a665c