### PR TITLE
Add INI config support for PostgreSQL upgrade

### DIFF
--- a/apps/db/postgresql/upgrade_pg15_to_pg16.ini
+++ b/apps/db/postgresql/upgrade_pg15_to_pg16.ini
@@ -1,0 +1,7 @@
+[upgrade]
+dump_file = pg15_dump.sql
+user = postgres
+password =
+old_data_dir = /var/lib/postgresql/15/main
+old_bin_dir = /usr/lib/postgresql/15/bin
+new_bin_dir = /usr/lib/postgresql/16/bin

--- a/apps/db/postgresql/upgrade_pg15_to_pg16.py
+++ b/apps/db/postgresql/upgrade_pg15_to_pg16.py
@@ -2,6 +2,7 @@
 """Utility to migrate a PostgreSQL 15 cluster to version 16 using dump/restore."""
 
 import argparse
+import configparser
 import os
 import subprocess
 from pathlib import Path
@@ -38,32 +39,57 @@ def main() -> None:
         description="Upgrade PostgreSQL data from version 15 to 16 using pg_dumpall and psql"
     )
     parser.add_argument(
-        "--dump-file",
-        default="pg15_dump.sql",
-        help="Temporary dump file path",
+        "--config",
+        default="upgrade_pg15_to_pg16.ini",
+        help="Path to configuration ini file",
     )
-    parser.add_argument(
-        "--user",
-        default="postgres",
-        help="Database superuser name",
-    )
+    parser.add_argument("--dump-file", default=None, help="Temporary dump file path")
+    parser.add_argument("--user", default=None, help="Database superuser name")
+    parser.add_argument("--password", default=None, help="Database password")
     parser.add_argument(
         "--old-bin-dir",
-        default="/usr/lib/postgresql/15/bin",
+        default=None,
         help="Path to PostgreSQL 15 binaries",
     )
     parser.add_argument(
         "--old-data-dir",
-        default="/var/lib/postgresql/15/main",
+        default=None,
         help="Data directory for the PostgreSQL 15 server",
     )
     parser.add_argument(
-
         "--new-bin-dir",
-        default="/usr/lib/postgresql/16/bin",
+        default=None,
         help="Path to PostgreSQL 16 binaries",
     )
+
     args = parser.parse_args()
+
+    defaults = {
+        "dump_file": "pg15_dump.sql",
+        "user": "postgres",
+        "password": "",
+        "old_bin_dir": "/usr/lib/postgresql/15/bin",
+        "old_data_dir": "/var/lib/postgresql/15/main",
+        "new_bin_dir": "/usr/lib/postgresql/16/bin",
+    }
+
+    config = configparser.ConfigParser()
+    if Path(args.config).exists():
+        config.read(args.config)
+        if config.has_section("upgrade"):
+            section = config["upgrade"]
+            defaults.update(
+                {k: section.get(k, v) for k, v in defaults.items()}
+            )
+
+    args.dump_file = args.dump_file or defaults["dump_file"]
+    args.user = args.user or defaults["user"]
+    args.password = args.password or defaults["password"]
+    args.old_bin_dir = args.old_bin_dir or defaults["old_bin_dir"]
+    args.old_data_dir = args.old_data_dir or defaults["old_data_dir"]
+    args.new_bin_dir = args.new_bin_dir or defaults["new_bin_dir"]
+
+    os.environ["PGPASSWORD"] = args.password
 
     dump_path = Path(args.dump_file).resolve()
     old_dumpall = Path(args.old_bin_dir) / "pg_dumpall"


### PR DESCRIPTION
## Summary
- add configuration file to supply default parameters for the PostgreSQL upgrade
- update `upgrade_pg15_to_pg16.py` to load values from an ini file and support password setting

## Testing
- `python -m py_compile apps/db/postgresql/upgrade_pg15_to_pg16.py`
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_687a78b13304833193a3c8458dbd8af9