### PR TITLE
Add INI config support for PostgreSQL upgrade

### DIFF
--- a/apps/db/postgresql/upgrade_pg15_to_pg16.ini
+++ b/apps/db/postgresql/upgrade_pg15_to_pg16.ini
@@ -1,0 +1,7 @@
+[upgrade]
+dump_file = pg15_dump.sql
+user = postgres
+password =
+old_data_dir = /var/lib/postgresql/15/main
+old_bin_dir = /usr/lib/postgresql/15/bin
+new_bin_dir = /usr/lib/postgresql/16/bin


### PR DESCRIPTION
## Summary
- add configuration file to supply default parameters for the PostgreSQL upgrade
- update `upgrade_pg15_to_pg16.py` to load values from an ini file and support password setting
- comment out server startup and shutdown calls to prevent PostgreSQL from running

## Testing
- `python -m py_compile apps/db/postgresql/upgrade_pg15_to_pg16.py`
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_687a78b13304833193a3c8458dbd8af9