### PR TITLE
Add OLED IP display example

### DIFF
--- a/apps/oled_piroman5/README.md
+++ b/apps/oled_piroman5/README.md
@@ -1,0 +1,9 @@
+# OLED IP Display
+
+Simple example using **piroman5** Raspberry Pi OLED driver (based on `luma.oled`) to show the current IP address on a small OLED screen.
+
+## Running
+
+```bash
+sudo python3 ip_display.py
+```

--- a/apps/oled_piroman5/ip_display.py
+++ b/apps/oled_piroman5/ip_display.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Display current IP address on OLED using piroman5 driver."""
+
+import time
+import subprocess
+
+# piroman5 OLED driver, built on luma.oled
+from luma.core.interface.serial import i2c
+from luma.oled.device import ssd1306
+from luma.core.render import canvas
+from PIL import ImageFont
+
+
+def get_ip_address(interface="eth0"):
+    """Return the IPv4 address for a network interface."""
+    cmd = ["ip", "addr", "show", interface]
+    output = subprocess.check_output(cmd, encoding="utf-8")
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith("inet "):
+            return line.split()[1].split("/")[0]
+    return "0.0.0.0"
+
+
+def main():
+    # Initialize OLED display via I2C
+    serial = i2c(port=1, address=0x3C)
+    device = ssd1306(serial)
+
+    font = ImageFont.load_default()
+
+    while True:
+        ip = get_ip_address("eth0")
+        with canvas(device) as draw:
+            draw.text((0, 0), "IP Address", font=font, fill=255)
+            draw.text((0, 16), ip, font=font, fill=255)
+        time.sleep(3)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add ip_display.py using piroman5-based OLED driver
- document how to run the example

## Testing
- `python3 -m py_compile apps/oled_piroman5/ip_display.py`

------
https://chatgpt.com/codex/tasks/task_e_687e9bfb5a288331878233a15513404e