### PR TITLE
Add install instructions for OLED IP display

### DIFF
--- a/apps/oled_piroman5/README.md
+++ b/apps/oled_piroman5/README.md
@@ -1,0 +1,19 @@
+# OLED IP Display
+
+Simple example using **piroman5** Raspberry Pi OLED driver (based on `luma.oled`) to show the current IP address on a small OLED screen. The script also turns on the cooling fan connected to BCM pin 18 on the piroman5 max board.
+
+## Installation
+
+Install the required Python packages with pip (use `sudo` on Raspberry Pi OS):
+
+```bash
+pip3 install -r requirements.txt
+```
+
+## Running
+
+```bash
+sudo python3 ip_display.py
+```
+
+The fan will remain on while the script is running.

--- a/apps/oled_piroman5/ip_display.py
+++ b/apps/oled_piroman5/ip_display.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Display current IP address on OLED using piroman5 driver.
+
+Requirements installed with::
+
+    pip3 install -r requirements.txt
+"""
+
+import time
+import subprocess
+
+# piroman5 OLED driver, built on luma.oled
+from luma.core.interface.serial import i2c
+from luma.oled.device import ssd1306
+from luma.core.render import canvas
+from PIL import ImageFont
+import RPi.GPIO as GPIO
+
+# pin used to control the cooling fan on piroman5 max
+FAN_PIN = 18
+
+
+def get_ip_address(interface="eth0"):
+    """Return the IPv4 address for a network interface."""
+    cmd = ["ip", "addr", "show", interface]
+    output = subprocess.check_output(cmd, encoding="utf-8")
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith("inet "):
+            return line.split()[1].split("/")[0]
+    return "0.0.0.0"
+
+
+def main():
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setup(FAN_PIN, GPIO.OUT)
+    GPIO.output(FAN_PIN, GPIO.HIGH)
+
+    # Initialize OLED display via I2C
+    serial = i2c(port=1, address=0x3C)
+    device = ssd1306(serial)
+
+    font = ImageFont.load_default()
+
+    try:
+        while True:
+            ip = get_ip_address("eth0")
+            with canvas(device) as draw:
+                draw.text((0, 0), "IP Address", font=font, fill=255)
+                draw.text((0, 16), ip, font=font, fill=255)
+            time.sleep(3)
+    finally:
+        GPIO.output(FAN_PIN, GPIO.LOW)
+        GPIO.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/oled_piroman5/requirements.txt
+++ b/apps/oled_piroman5/requirements.txt
@@ -1,0 +1,3 @@
+luma.oled
+Pillow
+RPi.GPIO


### PR DESCRIPTION
## Summary
- document package installation steps for the OLED IP display example
- reference `requirements.txt` from the script and README
- include new `requirements.txt` listing luma.oled, Pillow, and RPi.GPIO

## Testing
- `python3 -m py_compile apps/oled_piroman5/ip_display.py`


------
https://chatgpt.com/codex/tasks/task_e_687e9bfb5a288331878233a15513404e