### PR TITLE
Adjust OLED display for cron

### DIFF
--- a/apps/oled_piroman5/README.md
+++ b/apps/oled_piroman5/README.md
@@ -1,0 +1,21 @@
+# OLED IP Display
+
+Simple example using **piroman5** Raspberry Pi OLED driver (based on `luma.oled`) to show the current IP address and timestamp on a small OLED screen. The fan on BCM pin 18 of the piroman5 max board is automatically controlled based on the CPU temperature.
+
+## Installation
+
+Install the required Python packages with pip (use `sudo` on Raspberry Pi OS):
+
+```bash
+pip3 install -r requirements.txt
+```
+
+## Running
+
+Add an entry to ``crontab`` so the script runs every minute:
+
+```bash
+* * * * * /usr/bin/python3 /path/to/ip_display.py
+```
+
+Each run updates the OLED with the current IP address and the date/time (including seconds). The fan turns on when the CPU temperature exceeds 55 °C and turns off once it drops below that threshold.

--- a/apps/oled_piroman5/ip_display.py
+++ b/apps/oled_piroman5/ip_display.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Display IP address and time on the OLED using the piroman5 driver.
+
+This script is designed to be called from ``cron`` once per minute.
+It updates the OLED with the current IPv4 address and timestamp, and
+controls the cooling fan on the piroman5 max board when the CPU
+temperature exceeds ``55°C``.
+
+Dependencies can be installed with::
+
+    pip3 install -r requirements.txt
+"""
+
+from datetime import datetime
+import subprocess
+
+# piroman5 OLED driver, built on luma.oled
+from luma.core.interface.serial import i2c
+from luma.oled.device import ssd1306
+from luma.core.render import canvas
+from PIL import ImageFont
+import atexit
+from gpiozero import OutputDevice, CPUTemperature, Device
+
+# pin used to control the cooling fan on piroman5 max
+FAN_PIN = 18
+# temperature threshold in Celsius for turning the fan on
+TEMP_THRESHOLD = 55.0
+
+
+def get_ip_address(interface="eth0"):
+    """Return the IPv4 address for a network interface."""
+    cmd = ["ip", "addr", "show", interface]
+    output = subprocess.check_output(cmd, encoding="utf-8")
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith("inet "):
+            return line.split()[1].split("/")[0]
+    return "0.0.0.0"
+
+
+def main():
+    """Update the OLED and control the cooling fan once."""
+
+    # Prevent gpiozero from resetting the pin states on exit so the fan
+    # remains in the state we set. Older versions of gpiozero may not
+    # expose ``Device._shutdown``, so handle that case gracefully.
+    if hasattr(Device, "_shutdown"):
+        try:
+            atexit.unregister(Device._shutdown)
+        except Exception:
+            pass
+
+    fan = OutputDevice(FAN_PIN, active_high=True)
+    cpu = CPUTemperature()
+
+    # Determine IP address and current time
+    ip = get_ip_address("eth0")
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    if cpu.temperature >= TEMP_THRESHOLD:
+        fan.on()
+    else:
+        fan.off()
+
+    # Initialize OLED display via I2C
+    serial = i2c(port=1, address=0x3C)
+    device = ssd1306(serial)
+
+    font = ImageFont.load_default()
+
+    # Draw the information once. The display retains the last frame so
+    # the text remains visible after the program ends.
+    with canvas(device) as draw:
+        draw.text((0, 0), ip, font=font, fill=255)
+        draw.text((0, 16), now, font=font, fill=255)
+
+if __name__ == "__main__":
+    main()

--- a/apps/oled_piroman5/requirements.txt
+++ b/apps/oled_piroman5/requirements.txt
@@ -1,0 +1,3 @@
+luma.oled
+Pillow
+gpiozero


### PR DESCRIPTION
## Summary
- show the current IP address and timestamp on the OLED
- check CPU temperature once and toggle the fan
- update documentation for running via cron
- handle missing gpiozero shutdown handler

## Testing
- `python3 -m py_compile apps/oled_piroman5/ip_display.py`


------
https://chatgpt.com/codex/tasks/task_e_687e9bfb5a288331878233a15513404e