### PR TITLE
Add progress bar model download for Qwen demo

### DIFF
--- a/apps/deeplearning/qwen_streamlit/README.md
+++ b/apps/deeplearning/qwen_streamlit/README.md
@@ -18,4 +18,7 @@ Run the Streamlit application:
 streamlit run app.py
 ```
 
-Enter a sentence in the text input box and the model will generate a response.
+The application will automatically download the `Qwen/Qwen1.5-0.5B-Chat` model
+on first run if it is not available locally. A progress bar will be shown while
+the files are being retrieved. After the download completes, enter a sentence in
+the text input box and the model will generate a response.

--- a/apps/deeplearning/qwen_streamlit/app.py
+++ b/apps/deeplearning/qwen_streamlit/app.py
@@ -1,6 +1,58 @@
+import os
+import threading
+import time
+
 import streamlit as st
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import torch
+
+
+def download_model(model_name: str) -> None:
+    """Download the model showing a progress bar."""
+    try:
+        from huggingface_hub import snapshot_download
+    except Exception:
+        st.error("huggingface_hub is required to download models")
+        st.stop()
+
+    progress = st.progress(0)
+
+    def _download() -> None:
+        try:
+            snapshot_download(repo_id=model_name, local_dir=model_name, resume_download=True)
+        except Exception as exc:
+            st.session_state.download_error = str(exc)
+
+    thread = threading.Thread(target=_download)
+    thread.start()
+    pct = 0
+    while thread.is_alive():
+        pct = min(100, pct + 1)
+        progress.progress(pct / 100.0)
+        time.sleep(1)
+
+    thread.join()
+    progress.progress(1.0)
+    if "download_error" in st.session_state:
+        st.error("Failed to download model: " + st.session_state.download_error)
+        st.stop()
+    st.success("Download complete")
+
+
+def ensure_model(model_name: str) -> None:
+    """Ensure model files are available, otherwise download them."""
+    if os.path.isdir(model_name):
+        return
+    try:
+        from huggingface_hub import hf_hub_download
+
+        hf_hub_download(repo_id=model_name, filename="config.json", local_files_only=True)
+        return
+    except Exception:
+        pass
+
+    download_model(model_name)
+
 
 
 def load_model(model_name: str):
@@ -22,6 +74,8 @@ def generate_response(prompt: str, tokenizer, model, device):
 
 st.title("Qwen Chat")
 model_name = "Qwen/Qwen1.5-0.5B-Chat"
+
+ensure_model(model_name)
 
 @st.cache_resource
 def get_model():


### PR DESCRIPTION
## Summary
- ensure the Qwen model downloads automatically in the `qwen_streamlit` demo
- display a Streamlit progress bar while the model is retrieved
- document the automatic download behavior in the README

## Testing
- `python3 -m py_compile apps/deeplearning/qwen_streamlit/app.py`
- `python3 -m py_compile apps/qwen_streamlit_qa/app.py`
- `flake8 apps/deeplearning/qwen_streamlit/app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838a506b0c8331b1d2b1b795de7b0e