### PR TITLE
Add MPS device support to Qwen Streamlit

### DIFF
--- a/apps/deeplearning/qwen_streamlit/README.md
+++ b/apps/deeplearning/qwen_streamlit/README.md
@@ -18,4 +18,10 @@ Run the Streamlit application:
 streamlit run app.py
 ```
 
-Enter a sentence in the text input box and the model will generate a response.
+The application will automatically download the `Qwen/Qwen1.5-0.5B-Chat` model
+on first run if it is not available locally. When this happens the program
+prints a progress bar in the terminal using the **rich** library and the
+Streamlit UI will only appear once the download finishes. After the model is
+ready, enter a sentence in the text input box and the model will generate a
+response. If PyTorch detects the MPS backend (for Apple Silicon), the app will
+use it automatically for faster inference.


### PR DESCRIPTION
## Summary
- use MPS backend when available in the qwen Streamlit demo
- document automatic MPS usage

## Testing
- `python3 -m py_compile apps/deeplearning/qwen_streamlit/app.py`
- `python3 -m py_compile apps/qwen_streamlit_qa/app.py`
- `flake8 apps/deeplearning/qwen_streamlit/app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838a506b0c8331b1d2b1b795de7b0e