### PR TITLE
Add receipt OCR Streamlit app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tmp_this.ini
 
 # 특정 파일 제외
 #my_secret_file.txt
+nocommit/

--- a/apps/receipt_ocr/README.md
+++ b/apps/receipt_ocr/README.md
@@ -1,0 +1,13 @@
+# Receipt OCR Streamlit App
+
+This app lets you upload receipt images and extract text using OCR. Up to 10 files
+can be processed. Uploaded files are saved in the `nocommit` directory, which is
+ignored by git. Amounts found in each receipt are summed and receipts are grouped
+by detected address.
+
+## Usage
+```
+streamlit run apps/receipt_ocr/receipt_ocr_app.py
+```
+Place your OpenAI API key in `nocommit/openai_key.txt` if you plan to extend the
+app with OpenAI features.

--- a/apps/receipt_ocr/receipt_ocr_app.py
+++ b/apps/receipt_ocr/receipt_ocr_app.py
@@ -1,0 +1,92 @@
+import os
+import re
+from typing import List, Dict
+
+import streamlit as st
+from PIL import Image
+
+try:
+    import pytesseract
+except Exception as e:
+    pytesseract = None
+    st.error("pytesseract is not installed. OCR functionality will not work.")
+
+NOCOMMIT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "nocommit")
+os.makedirs(NOCOMMIT_DIR, exist_ok=True)
+
+AMOUNT_REGEX = re.compile(r"([\d,.]+)")
+ADDRESS_KEYWORDS = ["Address", "주소"]
+
+
+def extract_amount(text: str) -> int:
+    """Extract the first integer-like value from text."""
+    matches = AMOUNT_REGEX.findall(text)
+    for m in matches[::-1]:  # try from last to handle typical layout
+        cleaned = m.replace(",", "").replace(".", "")
+        if cleaned.isdigit():
+            return int(cleaned)
+    return 0
+
+
+def extract_address(text: str) -> str:
+    lines = text.splitlines()
+    for line in lines:
+        if any(k.lower() in line.lower() for k in ADDRESS_KEYWORDS):
+            return line.strip()
+    return "Unknown"
+
+
+def ocr_image(path: str) -> str:
+    if pytesseract is None:
+        return ""
+    img = Image.open(path)
+    return pytesseract.image_to_string(img, lang="eng+kor")
+
+
+def process_receipts(files: List[Dict]) -> List[Dict]:
+    receipts = []
+    for file in files:
+        save_path = os.path.join(NOCOMMIT_DIR, file.name)
+        with open(save_path, "wb") as out:
+            out.write(file.getbuffer())
+        text = ocr_image(save_path)
+        amount = extract_amount(text)
+        address = extract_address(text)
+        receipts.append({
+            "filename": file.name,
+            "text": text,
+            "amount": amount,
+            "address": address,
+        })
+    return receipts
+
+
+def summarize(receipts: List[Dict]):
+    total = sum(r["amount"] for r in receipts)
+    st.write(f"**총 금액 합계: {total}**")
+    grouped: Dict[str, List[Dict]] = {}
+    for r in receipts:
+        grouped.setdefault(r["address"], []).append(r)
+    for addr, items in grouped.items():
+        st.subheader(addr)
+        for item in items:
+            st.write(f"{item['filename']}: {item['amount']}")
+
+
+st.title("Receipt OCR")
+uploaded_files = st.file_uploader(
+    "영수증 스캔 파일 업로드 (여러개 선택 가능)",
+    type=["png", "jpg", "jpeg", "webp"],
+    accept_multiple_files=True,
+)
+
+if uploaded_files:
+    if len(uploaded_files) > 10:
+        st.warning("최대 10개 파일만 처리합니다. 일부만 사용합니다.")
+        uploaded_files = uploaded_files[:10]
+    receipts = process_receipts(uploaded_files)
+    summarize(receipts)
+    with st.expander("세부 내용 보기"):
+        for r in receipts:
+            st.write(f"### {r['filename']}")
+            st.text(r['text'])


### PR DESCRIPTION
## Summary
- add a Streamlit app that performs OCR on uploaded receipts
- save uploads to `nocommit` directory and group results by address
- document new app in `apps/receipt_ocr/README.md`
- ignore `nocommit` directory in `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_688a74eababc8331b0e71c2963c4ec85