### PR TITLE
Add business card OCR RAGFlow app

### DIFF
--- a/apps/ragflow_card_rag/README.md
+++ b/apps/ragflow_card_rag/README.md
@@ -1,0 +1,11 @@
+# ragflow_card_rag
+
+Streamlit 앱으로 명함 이미지(jpg, png)를 업로드하여 텍스트를 추출하고 RAGFlow 기반으로 질문에 답변합니다.
+
+## 실행 방법
+
+```bash
+streamlit run app.py
+```
+
+OpenAI API 키는 `nocommit/nocommit_key.txt` 파일에서 읽어옵니다.

--- a/apps/ragflow_card_rag/app.py
+++ b/apps/ragflow_card_rag/app.py
@@ -1,0 +1,76 @@
+import os
+import base64
+
+import streamlit as st
+from openai import OpenAI
+
+try:
+    from ragflow import RAGFlow  # pragma: no cover
+except Exception:  # ragflow not installed
+    from ragflow_card_rag.ragflow_simple import SimpleRAGFlow as RAGFlow  # type: ignore
+
+
+def load_api_key() -> str:
+    key = os.getenv("OPENAI_API_KEY")
+    if key:
+        return key
+    candidates = [
+        os.path.join(os.path.dirname(__file__), "nocommit", "nocommit_key.txt"),
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "nocommit", "nocommit_key.txt"),
+    ]
+    for cand in candidates:
+        if os.path.isfile(cand):
+            try:
+                with open(cand, "r", encoding="utf-8") as f:
+                    return f.read().strip()
+            except Exception:
+                continue
+    return ""
+
+
+def ocr_image(client: OpenAI, image_bytes: bytes) -> str:
+    b64 = base64.b64encode(image_bytes).decode("utf-8")
+    resp = client.responses.create(
+        model="gpt-4o-mini",
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Extract all text from this business card image."},
+                    {"type": "input_image", "image": b64},
+                ],
+            }
+        ],
+    )
+    try:
+        return resp.output[0].content[0].text.strip()
+    except Exception:
+        # Fallback for older clients
+        return resp.output_text.strip() if hasattr(resp, "output_text") else ""
+
+
+API_KEY = load_api_key()
+client = OpenAI(api_key=API_KEY)
+
+st.set_page_config(page_title="Business Card RAG")
+st.title("📇 명함 OCR RAG (RAGFlow)")
+
+if "rag" not in st.session_state:
+    st.session_state.rag = RAGFlow(client)
+
+uploaded = st.file_uploader("명함 이미지 업로드", type=["jpg", "jpeg", "png"], accept_multiple_files=True)
+
+if uploaded:
+    for uf in uploaded:
+        text = ocr_image(client, uf.read())
+        if text:
+            st.session_state.rag.add_document(text)
+            st.success(f"{uf.name} 처리 완료")
+        else:
+            st.warning(f"{uf.name} 에서 텍스트를 추출하지 못했습니다")
+
+st.markdown("---")
+question = st.text_input("질문을 입력하세요")
+if question:
+    answer = st.session_state.rag.query(question)
+    st.write("**답변:**", answer)

--- a/apps/ragflow_card_rag/ragflow_simple.py
+++ b/apps/ragflow_card_rag/ragflow_simple.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+class SimpleRAGFlow:
+    """A minimal in-memory RAG pipeline used when ragflow library is unavailable."""
+
+    def __init__(self, client, embed_model="text-embedding-3-small", llm_model="gpt-4o-mini"):
+        self.client = client
+        self.embed_model = embed_model
+        self.llm_model = llm_model
+        self.docs = []
+        self.embs = []
+
+    def add_document(self, text: str):
+        """Store text and its embedding."""
+        emb_resp = self.client.embeddings.create(model=self.embed_model, input=[text])
+        emb = np.array(emb_resp.data[0].embedding)
+        self.docs.append(text)
+        self.embs.append(emb)
+
+    def query(self, question: str) -> str:
+        """Retrieve relevant text and ask LLM for an answer."""
+        if not self.docs:
+            prompt = question
+        else:
+            q_emb_resp = self.client.embeddings.create(model=self.embed_model, input=[question])
+            q_emb = np.array(q_emb_resp.data[0].embedding)
+            sims = [float(np.dot(q_emb, e) / (np.linalg.norm(q_emb) * np.linalg.norm(e))) for e in self.embs]
+            best_idx = int(np.argmax(sims))
+            context = self.docs[best_idx]
+            prompt = f"다음 명함 정보:\n{context}\n\n질문: {question}"
+        resp = self.client.chat.completions.create(
+            model=self.llm_model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content


### PR DESCRIPTION
## Summary
- Add Streamlit app for uploading business card images, extracting text via OpenAI vision, and querying through a simple RAGFlow pipeline
- Include fallback in case `ragflow` library is unavailable

## Testing
- `python -m py_compile apps/ragflow_card_rag/ragflow_simple.py apps/ragflow_card_rag/app.py`
- `pytest` *(fails: ModuleNotFoundError: pytesseract, pandas, torch, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688b4b994c44833184668d944b8b70b4