### PR TITLE
Ensure chart rendering completes before capturing SHT20 dashboard

### DIFF
--- a/apps/sht20/sht20_dashboard.py
+++ b/apps/sht20/sht20_dashboard.py
@@ -112,6 +112,7 @@ def index():
                     options: { scales: { x: { ticks: { maxTicksLimit: 6 } } } }
                 });
             });
+            window.status = 'ready';
             </script>
         </body>
         </html>
@@ -125,7 +126,12 @@ def capture_and_send(url, outfile="dashboard.jpg"):
     try:
         import imgkit
 
-        options = {"javascript-delay": 2000, "enable-local-file-access": ""}
+        options = {
+            "javascript-delay": 2000,
+            "enable-local-file-access": "",
+            "window-status": "ready",
+            "no-stop-slow-scripts": "",
+        }
         imgkit.from_url(url, outfile, options=options)
         subprocess.run(["telegram-send", "-f", outfile], check=False)
     except Exception as exc:  # pragma: no cover


### PR DESCRIPTION
## Summary
- Wait for Chart.js charts to finish rendering by setting `window.status`
- Capture screenshots only after charts are ready using `window-status` option in imgkit

## Testing
- `python -m py_compile apps/sht20/sht20_dashboard.py`
- `timeout 5 python apps/sht20/sht20_dashboard.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_688f3304ae508331aa3850742f88acf6