### PR TITLE
Ensure dashboard charts render in screenshot

### DIFF
--- a/apps/sht20/sht20_dashboard.py
+++ b/apps/sht20/sht20_dashboard.py
@@ -19,6 +19,43 @@ INFLUX_MEASUREMENT = "temperature"
 app = Flask(__name__)
 
 
+def find_chrome_executable():
+    """Return path to a Chrome/Chromium executable if installed.
+
+    Some environments (e.g. Raspberry Pi) may have an incompatible
+    pyppeteer-managed Chromium on ``$PATH``.  We iterate through common
+    browser commands and verify that the located executable actually runs.
+    """
+
+    candidates = [
+        "chromium-browser",
+        "chromium",
+        "google-chrome",
+        "google-chrome-stable",
+        "chrome",
+    ]
+
+    for name in candidates:
+        path = shutil.which(name)
+        if not path:
+            continue
+        # Skip pyppeteer's bundled Chromium which may be the wrong arch
+        if "pyppeteer" in path:
+            continue
+        try:
+            subprocess.run(
+                [path, "--version"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=True,
+            )
+        except Exception:
+            # If running the binary fails (e.g. exec format error), try next
+            continue
+        return path
+    return None
+
+
 def get_ip_address():
     """Return the host's primary IP address."""
     ip = "127.0.0.1"
@@ -106,10 +143,12 @@ def index():
             {% endfor %}
             <script>
             // Ensure the entire DOM is loaded before trying to access elements
-            document.addEventListener('DOMContentLoaded', (event) => {
+            document.addEventListener('DOMContentLoaded', () => {
                 const weeks = {{ weeks|tojson }};
                 let chartsRenderedCount = 0;
                 const totalCharts = weeks.length;
+                // Flag used by the screenshot routine to detect chart completion
+                window.CHARTS_READY = false;
 
                 weeks.forEach((wk, idx) => {
                     const ctx = document.getElementById('chart'+(idx+1)).getContext('2d');
@@ -127,7 +166,7 @@ def index():
                             }]
                         },
                         options: {
-                            responsive: true,
+                            responsive: false,
                             maintainAspectRatio: false,
                             scales: {
                                 x: {
@@ -160,10 +199,9 @@ def index():
                         }
                     });
                     chartsRenderedCount++;
-                    // After all charts are rendered, set window.status
+                    // After all charts are rendered, set the global flag
                     if (chartsRenderedCount === totalCharts) {
-                        console.log("All charts rendered. Setting window.status to 'ready'.");
-                        window.status = 'ready';
+                        window.CHARTS_READY = true;
                     }
                 });
             });
@@ -177,26 +215,80 @@ def index():
 
 
 
+async def _capture_with_pyppeteer(url, outfile):
+    """Use headless Chrome to capture a screenshot of the dashboard."""
+    from pyppeteer import errors, launch
+
+    chrome_path = find_chrome_executable()
+    if not chrome_path:
+        raise RuntimeError(
+            "Chrome/Chromium not found. Please install it to capture screenshots."
+        )
+
+    # Extra flags help avoid crashes on constrained systems (e.g. Raspberry Pi)
+    launch_args = [
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-gpu",
+        "--no-zygote",
+    ]
+
+    try:
+        browser = await launch(executablePath=chrome_path, args=launch_args)
+    except errors.BrowserError as exc:
+        raise RuntimeError(f"Failed to launch Chrome: {exc}") from exc
+    try:
+        page = await browser.newPage()
+        await page.setViewport({"width": 1024, "height": 768})
+        # Wait for all network activity (including Chart.js) to finish
+        await page.goto(url, {"waitUntil": "networkidle0"})
+        try:
+            # Wait until the page JS reports that charts are rendered
+            await page.waitForFunction("window.CHARTS_READY === true", timeout=15000)
+        except Exception:
+            # Fall back to a short delay if the flag wasn't set in time
+            await page.waitForTimeout(2000)
+        await page.screenshot({"path": outfile, "fullPage": True})
+    finally:
+        try:
+            await browser.close()
+        except errors.BrowserError:
+            pass
+
+
 def capture_and_send(url, outfile="dashboard.jpg"):
     """Capture the given URL to an image and send via telegram-send."""
     try:
-        import imgkit
+        import asyncio
+        from pyppeteer import errors
 
-        options = {
-            "javascript-delay": 2000,
-            "enable-local-file-access": "",
-            "window-status": "ready",
-            "no-stop-slow-scripts": "",
-        }
-        imgkit.from_url(url, outfile, options=options)
+        asyncio.get_event_loop().run_until_complete(
+            _capture_with_pyppeteer(url, outfile)
+        )
         subprocess.run(["telegram-send", "-f", outfile], check=False)
+    except errors.BrowserError as exc:  # pragma: no cover
+        print("Capture/send failed: headless Chrome crashed:", exc)
     except Exception as exc:  # pragma: no cover
         print("Capture/send failed:", exc)
 
 
-if __name__ == "__main__":
-    import shutil
+def wait_for_server(url, timeout=30):
+    """Poll ``url`` until it responds or ``timeout`` seconds elapse."""
+    import urllib.request
 
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            with urllib.request.urlopen(url) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            time.sleep(0.5)
+    return False
+
+
+if __name__ == "__main__":
     influx_proc = start_influxdb()
     if influx_proc is not None:
         import atexit
@@ -210,8 +302,9 @@ if __name__ == "__main__":
     server.daemon = True
     server.start()
 
-    # Give the server a moment to start before capturing
-    time.sleep(5)
-    capture_and_send(url)
+    if wait_for_server(url):
+        capture_and_send(url)
+    else:
+        print("Dashboard server did not become ready in time")
 
     server.join()


### PR DESCRIPTION
## Summary
- capture dashboard with headless Chrome so Chart.js renders before screenshot
- wait for chart creation to complete before taking screenshot
- verify Chrome/Chromium is installed before launching pyppeteer
- skip pyppeteer's bundled Chromium and validate browser executable to avoid exec format errors
- start capture only after dashboard server responds and harden Chrome launch with additional flags
- avoid Chrome crash on launch by removing single-process flag and catching BrowserError to raise a clearer message

## Testing
- `python -m py_compile apps/sht20/sht20_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_688f37147d1483318dd4c695212af04f