### PR TITLE
Send 48‑hour InfluxDB temperature chart via Telegram

### DIFF
--- a/apps/sht20/sht20_dashboard.py
+++ b/apps/sht20/sht20_dashboard.py
@@ -1,36 +1,16 @@
 import os
-import socket
 import subprocess
 import time
-from threading import Thread
 import shutil
+import urllib.request
+import urllib.parse
 
-from flask import Flask, render_template_string
-from influxdb import InfluxDBClient
-
-PORT = 5001
 INFLUX_HOST = "localhost"
 INFLUX_PORT = 8086
 INFLUX_USER = os.environ.get("INFLUX_USER", "admin")
 INFLUX_PASS = os.environ.get("INFLUX_PASS", "admin")
 INFLUX_DB = "sht20"
 INFLUX_MEASUREMENT = "temperature"
-
-app = Flask(__name__)
-
-
-def get_ip_address():
-    """Return the host's primary IP address."""
-    ip = "127.0.0.1"
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    try:
-        s.connect(("8.8.8.8", 80))
-        ip = s.getsockname()[0]
-    except OSError:
-        pass
-    finally:
-        s.close()
-    return ip
 
 
 def start_influxdb():
@@ -50,168 +30,48 @@ def start_influxdb():
         return None
 
 
-def query_week(start_days, end_days):
-    """Query a week's worth of readings from InfluxDB."""
+def fetch_chart_png(outfile="temperature.png"):
+    """Request a 48-hour temperature graph from InfluxDB and save it."""
     query = (
-        f'SELECT "value" FROM "{INFLUX_MEASUREMENT}" '
-        f"WHERE time >= now() - {start_days}d AND time < now() - {end_days}d"
+        f'SELECT mean("value") FROM "{INFLUX_MEASUREMENT}" '
+        f'WHERE time > now() - 48h GROUP BY time(1h)'
     )
-    points = []
-    try:
-        client = InfluxDBClient(
-            host=INFLUX_HOST,
-            port=INFLUX_PORT,
-            username=INFLUX_USER,
-            password=INFLUX_PASS,
-            database=INFLUX_DB,
-        )
-        result = client.query(query)
-        for pt in result.get_points():
-            points.append({"time": pt["time"], "value": pt["value"]})
-    except Exception as exc:  # pragma: no cover
-        print("InfluxDB query error:", exc)
-    return points
-
-
-def fetch_weeks():
-    """Return data for four weeks, newest first."""
-    weeks = []
-    for i in range(4):
-        start = 7 * (i + 1)
-        end = 7 * i
-        weeks.append(query_week(start, end))
-    return weeks
-
-
-@app.route("/")
-def index():
-    weeks = fetch_weeks()
-    return render_template_string(
-        """
-        <html>
-        <head>
-            <title>SHT20 Charts</title>
-            <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-            <style>
-                body { font-family: sans-serif; margin: 20px; }
-                canvas { max-width: 800px; margin-bottom: 30px; border: 1px solid #eee; }
-                h1, h2 { color: #333; }
-            </style>
-        </head>
-        <body>
-            <h1>Monthly temperature overview</h1>
-            {% for w in range(4) %}
-            <h2>Week {{ loop.index }}</h2>
-            <canvas id="chart{{loop.index}}" width="800" height="400"></canvas> {# Increased dimensions for better clarity in capture #}
-            {% endfor %}
-            <script>
-            // Ensure the entire DOM is loaded before trying to access elements
-            document.addEventListener('DOMContentLoaded', (event) => {
-                const weeks = {{ weeks|tojson }};
-                let chartsRenderedCount = 0;
-                const totalCharts = weeks.length;
-
-                weeks.forEach((wk, idx) => {
-                    const ctx = document.getElementById('chart'+(idx+1)).getContext('2d');
-                    new Chart(ctx, {
-                        type: 'line',
-                        data: {
-                            labels: wk.map(p => new Date(p.time).toLocaleString()), // Format time for better readability
-                            datasets: [{
-                                label: 'Temperature',
-                                data: wk.map(p => p.value),
-                                borderColor: 'blue',
-                                backgroundColor: 'rgba(0, 0, 255, 0.1)', // Optional: shaded area below line
-                                fill: false, // Changed from true to false for a cleaner look if desired
-                                tension: 0.1 // Smooths the line
-                            }]
-                        },
-                        options: {
-                            responsive: true,
-                            maintainAspectRatio: false,
-                            scales: {
-                                x: {
-                                    ticks: {
-                                        maxTicksLimit: 8, // Adjust tick limit
-                                        autoSkip: true,
-                                        maxRotation: 45,
-                                        minRotation: 0
-                                    },
-                                    title: {
-                                        display: true,
-                                        text: 'Time'
-                                    }
-                                },
-                                y: {
-                                    title: {
-                                        display: true,
-                                        text: 'Temperature Value'
-                                    }
-                                }
-                            },
-                            animation: {
-                                duration: 0 // Disable animation for instant rendering before capture
-                            },
-                            plugins: {
-                                legend: {
-                                    display: true
-                                }
-                            }
-                        }
-                    });
-                    chartsRenderedCount++;
-                    // After all charts are rendered, set window.status
-                    if (chartsRenderedCount === totalCharts) {
-                        console.log("All charts rendered. Setting window.status to 'ready'.");
-                        window.status = 'ready';
-                    }
-                });
-            });
-            </script>
-        </body>
-        </html>
-        """,
-        weeks=weeks,
-    )
-
-
-
-
-def capture_and_send(url, outfile="dashboard.jpg"):
-    """Capture the given URL to an image and send via telegram-send."""
-    try:
-        import imgkit
-
-        options = {
-            "javascript-delay": 2000,
-            "enable-local-file-access": "",
-            "window-status": "ready",
-            "no-stop-slow-scripts": "",
+    params = urllib.parse.urlencode(
+        {
+            "db": INFLUX_DB,
+            "u": INFLUX_USER,
+            "p": INFLUX_PASS,
+            "q": query,
+            "format": "png",
         }
-        imgkit.from_url(url, outfile, options=options)
+    )
+    url = f"http://{INFLUX_HOST}:{INFLUX_PORT}/render?{params}"
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"InfluxDB render failed: HTTP {resp.status}")
+        with open(outfile, "wb") as fh:
+            fh.write(resp.read())
+    return outfile
+
+
+def fetch_and_send():
+    """Fetch the chart PNG and send it via telegram-send."""
+    outfile = "temperature.png"
+    try:
+        fetch_chart_png(outfile)
         subprocess.run(["telegram-send", "-f", outfile], check=False)
     except Exception as exc:  # pragma: no cover
         print("Capture/send failed:", exc)
 
 
 if __name__ == "__main__":
-    import shutil
-
     influx_proc = start_influxdb()
     if influx_proc is not None:
         import atexit
+
         atexit.register(influx_proc.terminate)
 
-    ip = get_ip_address()
-    url = f"http://{ip}:{PORT}"
-    print("Web page available at", url)
+    while True:
+        fetch_and_send()
+        time.sleep(12 * 3600)
 
-    server = Thread(target=lambda: app.run(host="0.0.0.0", port=PORT, use_reloader=False))
-    server.daemon = True
-    server.start()
-
-    # Give the server a moment to start before capturing
-    time.sleep(5)
-    capture_and_send(url)
-
-    server.join()


### PR DESCRIPTION
## Summary
- request a 48‑hour temperature graph from InfluxDB's render endpoint and save it as a PNG
- send the PNG via telegram-send on a 12-hour schedule

## Testing
- `python -m py_compile apps/sht20/sht20_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_688f37147d1483318dd4c695212af04f