### PR TITLE
Use port-based InfluxDB client and API-rendered charts

### DIFF
--- a/apps/sht20/sht20_influx.py
+++ b/apps/sht20/sht20_influx.py
@@ -4,56 +4,77 @@ import os
 import subprocess
 from pathlib import Path
 
-import matplotlib
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-import pandas as pd
-from influxdb_client import InfluxDBClient
+import requests
+from influxdb import InfluxDBClient
 
-INFLUX_URL = os.getenv("INFLUX_URL", "http://localhost:8086")
-INFLUX_TOKEN = os.getenv("INFLUX_TOKEN", "")
-INFLUX_ORG = os.getenv("INFLUX_ORG", "")
-INFLUX_BUCKET = os.getenv("INFLUX_BUCKET", "")
-MEASUREMENT = os.getenv("INFLUX_MEASUREMENT", "sht20")
+INFLUX_HOST = os.getenv("INFLUX_HOST", "localhost")
+INFLUX_PORT = int(os.getenv("INFLUX_PORT", "8086"))
+INFLUX_USER = os.getenv("INFLUX_USER", "")
+INFLUX_PASSWORD = os.getenv("INFLUX_PASSWORD", "")
+INFLUX_DB = os.getenv("INFLUX_DB", "")
+MEASUREMENT = os.getenv("INFLUX_MEASUREMENT", "temperature")
+INFLUX_FIELD = os.getenv("INFLUX_FIELD", "value")
 
-def fetch_week(client, start, stop):
-    query = f"""
-    from(bucket: \"{INFLUX_BUCKET}\")
-      |> range(start: {start.isoformat()}, stop: {stop.isoformat()})
-      |> filter(fn: (r) => r[\"_measurement\"] == \"{MEASUREMENT}\")
-    """
-    df = client.query_api().query_data_frame(org=INFLUX_ORG, query=query)
-    if isinstance(df, list):
-        df = pd.concat(df, ignore_index=True)
-    return df
 
-def plot_week(df, title, path):
-    plt.figure(figsize=(10, 4))
-    plt.plot(df["_time"], df["_value"])
-    plt.title(title)
-    plt.xlabel("Time")
-    plt.ylabel("Value")
-    plt.tight_layout()
-    plt.savefig(path)
-    plt.close()
+def render_week(host, port, db, user, password, measurement, field, start, stop, path):
+    query = (
+        f"SELECT mean(\"{field}\") FROM \"{measurement}\" "
+        f"WHERE time >= '{start.isoformat()}Z' AND time <= '{stop.isoformat()}Z'"
+    )
+    params = {
+        "db": db,
+        "u": user,
+        "p": password,
+        "q": query,
+        "epoch": "ms",
+        "format": "png",
+        "width": 1000,
+        "height": 400,
+    }
+    url = f"http://{host}:{port}/render"
+    resp = requests.get(url, params=params, timeout=10)
+    resp.raise_for_status()
+    with open(path, "wb") as file:
+        file.write(resp.content)
+
 
 def send_image(path):
     subprocess.run(["telegram-send", "--image", str(path)], check=False)
 
+
 def main():
-    client = InfluxDBClient(url=INFLUX_URL, token=INFLUX_TOKEN, org=INFLUX_ORG)
-    now = datetime.datetime.utcnow()
-    for i in range(4):
-        end = now - datetime.timedelta(weeks=i)
-        start = now - datetime.timedelta(weeks=i + 1)
-        df = fetch_week(client, start, end)
-        if df.empty:
-            continue
-        df["_time"] = pd.to_datetime(df["_time"])
-        img_path = Path(f"week_{i + 1}.png")
-        title = f"Week {i + 1}: {start.date()} to {end.date()}"
-        plot_week(df, title, img_path)
-        send_image(img_path)
+    try:
+        client = InfluxDBClient(
+            host=INFLUX_HOST,
+            port=INFLUX_PORT,
+            username=INFLUX_USER,
+            password=INFLUX_PASSWORD,
+            database=INFLUX_DB,
+        )
+        client.ping()
+
+        now = datetime.datetime.utcnow()
+        for i in range(4):
+            end = now - datetime.timedelta(weeks=i)
+            start = now - datetime.timedelta(weeks=i + 1)
+            img_path = Path(f"week_{i + 1}.png")
+            render_week(
+                INFLUX_HOST,
+                INFLUX_PORT,
+                INFLUX_DB,
+                INFLUX_USER,
+                INFLUX_PASSWORD,
+                MEASUREMENT,
+                INFLUX_FIELD,
+                start,
+                end,
+                img_path,
+            )
+            send_image(img_path)
+    except Exception as exc:
+        print(f"Failed to connect to InfluxDB: {exc}")
+
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- switch `sht20_influx.py` to use the legacy InfluxDB client with host/port instead of HTTP URLs
- generate weekly PNG charts using InfluxDB's `/render` API rather than local matplotlib rendering

## Testing
- `pip install requests influxdb` *(fails: Could not find a version that satisfies the requirement requests)*
- `python apps/sht20/sht20_influx.py` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6891fdca73488331a178b57f4fdceeaa