### PR TITLE
Wait for chart to render before screenshot

### DIFF
--- a/apps/sht20/sht20_ubuntu64.py
+++ b/apps/sht20/sht20_ubuntu64.py
@@ -87,6 +87,8 @@ INDEX_TEMPLATE = """
                 },
                 options: { scales: { x: { ticks: { maxTicksLimit: 6 } } } }
             });
+            window.CHARTS_READY = true;
+            window.status = 'ready';
         </script>
     </body>
 </html>
@@ -273,7 +275,7 @@ def capture_and_send(url, outfile="sht20.jpg"):
     try:
         import imgkit
 
-        options = {"javascript-delay": 2000, "enable-local-file-access": ""}
+        options = {"enable-local-file-access": "", "window-status": "ready"}
         imgkit.from_url(url, outfile, options=options)
         subprocess.run(["telegram-send", "-i", outfile], check=False)
     except Exception as exc:  # pragma: no cover - best effort logging


### PR DESCRIPTION
## Summary
- Mark chart-render completion via window status in SHT20 dashboard
- Wait for `window.status` to become `ready` before capturing screenshot

## Testing
- `python -m py_compile apps/sht20/sht20_ubuntu64.py`


------
https://chatgpt.com/codex/tasks/task_e_6894b5cbaba08331b49c1d376a7583dc