### PR TITLE
Send temperature chart PNG via Telegram

### DIFF
--- a/apps/sht20/sht20_ubuntu64.py
+++ b/apps/sht20/sht20_ubuntu64.py
@@ -5,7 +5,7 @@
 """SHT20 sensor reader with web and storage support.
 
 This script periodically reads temperature data from the SHT20 sensor and
-exposes it through a simple web page.  Every 30 seconds the following actions
+exposes it through a simple web page.  Every minute the following actions
 are performed:
 
 * Read the current temperature from the sensor.
@@ -28,9 +28,10 @@ import shutil
 import atexit
 
 import lgpio
-from flask import Flask, render_template_string
+from flask import Flask, render_template_string, jsonify
 from influxdb import InfluxDBClient
-from datetime import datetime
+from datetime import datetime, timedelta
+from rich.console import Console
 try:
     from zoneinfo import ZoneInfo
     TZ = ZoneInfo("Asia/Seoul")
@@ -49,6 +50,8 @@ bus = lgpio.i2c_open(1, SHT20_ADDR)
 
 # Flask application setup
 app = Flask(__name__)
+
+console = Console()
 
 # HTML template for the web page
 INDEX_TEMPLATE = """
@@ -74,7 +77,7 @@ INDEX_TEMPLATE = """
         <script>
             const recent = {{ recent|tojson }};
             const ctx = document.getElementById('tempChart').getContext('2d');
-            new Chart(ctx, {
+            const chart = new Chart(ctx, {
                 type: 'line',
                 data: {
                     labels: recent.map(p => p.time),
@@ -87,6 +90,20 @@ INDEX_TEMPLATE = """
                 },
                 options: { scales: { x: { ticks: { maxTicksLimit: 6 } } } }
             });
+
+            async function refresh() {
+                try {
+                    const resp = await fetch('/data');
+                    const data = await resp.json();
+                    chart.data.labels = data.map(p => p.time);
+                    chart.data.datasets[0].data = data.map(p => p.temperature);
+                    chart.update();
+                } catch (e) {
+                    console.log('Refresh failed', e);
+                }
+            }
+
+            setInterval(refresh, 60000);
         </script>
     </body>
 </html>
@@ -253,13 +270,30 @@ def start_influxdb():
 
 def send_plaintext(temp, ip, timestamp):
     """Send a plain text summary via telegram-send."""
+    total, _, free = shutil.disk_usage("/")
+    total_gb = total / (1024 ** 3)
+    free_gb = free / (1024 ** 3)
+    free_pct = free / total * 100 if total else 0
+
+    try:
+        with open("/proc/uptime", "r", encoding="utf-8") as f:
+            uptime_seconds = float(f.readline().split()[0])
+    except Exception:
+        uptime_seconds = 0
+    boot_time = datetime.now(TZ) - timedelta(seconds=uptime_seconds)
+    uptime_hours = uptime_seconds / 3600
+    uptime_days = uptime_seconds / 86400
+
     message = (
         f"Temperature: {temp:.2f} \u00b0C\n"
         f"IP Address: {ip}\n"
         f"Timestamp: {timestamp}\n"
         "\uc704\uce58: A\ub3d9 \uc11c\ubc84\uc2e4 \n"  # 위치: A동 서버실
         f"influxdb user, pass, DB, measurements {INFLUX_USER} {INFLUX_PASS} {INFLUX_DB} {INFLUX_MEASUREMENT} \n"
-        f"{QUERY_LAST_MONTH}"
+        f"{QUERY_LAST_MONTH}\n"
+        f"Disk: {total_gb:.2f}GB total, {free_gb:.2f}GB free ({free_pct:.1f}%)\n"
+        f"Boot: {boot_time.strftime('%Y-%m-%d %H:%M:%S')}\n"
+        f"Uptime: {uptime_hours:.1f}h ({uptime_days:.2f}d)"
     )
   
     try:
@@ -268,27 +302,63 @@ def send_plaintext(temp, ip, timestamp):
         print("Telegram send error:", exc)
 
 
-def capture_and_send(url, outfile="sht20.jpg"):
-    """Capture the given URL to an image and send via telegram-send."""
+def capture_and_send(outfile="sht20.png"):
+    """Generate a temperature chart from InfluxDB data and send it."""
     try:
-        import imgkit
+        import matplotlib.pyplot as plt
+        import seaborn as sns
 
-        options = {"javascript-delay": 2000, "enable-local-file-access": ""}
-        imgkit.from_url(url, outfile, options=options)
-        subprocess.run(["telegram-send", "-i", outfile], check=False)
+        client = InfluxDBClient(
+            host=INFLUX_HOST,
+            port=INFLUX_PORT,
+            username=INFLUX_USER,
+            password=INFLUX_PASS,
+            database=INFLUX_DB,
+        )
+        query = (
+            f'SELECT "value" FROM "{INFLUX_MEASUREMENT}" '
+            f'WHERE time >= now() - 48h ORDER BY time ASC'
+        )
+        result = client.query(query)
+        points = list(result.get_points())
+        if not points:
+            return
+
+        times = [
+            datetime.fromisoformat(p["time"].replace("Z", "+00:00"))
+            .astimezone(TZ)
+            for p in points
+        ]
+        temps = [p["value"] for p in points]
+
+        sns.set_theme(style="whitegrid")
+        fig, ax = plt.subplots(figsize=(10, 4))
+        sns.lineplot(x=times, y=temps, ax=ax, color="red")
+        ax.set_title("Recent Temperature (last 48h)")
+        ax.set_xlabel("Time")
+        ax.set_ylabel("Temperature (°C)")
+        fig.autofmt_xdate()
+        fig.tight_layout()
+        fig.savefig(outfile)
+        plt.close(fig)
+
+        outfile_path = os.path.abspath(outfile)
+        console.print(outfile_path)
+
+        subprocess.run(["telegram-send", "-i", outfile_path], check=False)
     except Exception as exc:  # pragma: no cover - best effort logging
         print("Capture/send failed:", exc)
 
 
 def update_loop():
-    """Background thread that updates sensor data every 30 seconds."""
+    """Background thread that updates sensor data every minute."""
     last_send = 0
     while True:
         temp_raw = reading(1)
         humi_raw = reading(2)
         if not temp_raw or not humi_raw:
             print("register error")
-            time.sleep(30)
+            time.sleep(60)
             continue
 
         temp_c, _ = calc(temp_raw, humi_raw)
@@ -305,10 +375,17 @@ def update_loop():
         now = time.monotonic()
         if now - last_send >= SEND_INTERVAL:
             send_plaintext(temp_c, ip, timestamp)
+            capture_and_send()
             last_send = now
 
 
-        time.sleep(30)
+        time.sleep(60)
+
+
+@app.route("/data")
+def data():
+    """Return recent temperature points as JSON."""
+    return jsonify(query_recent_temperatures())
 
 
 @app.route("/")
@@ -346,8 +423,4 @@ if __name__ == "__main__":
     )
     server.daemon = True
     server.start()
-
-    time.sleep(5)
-    capture_and_send("http://localhost:5000")
-
     server.join()


### PR DESCRIPTION
## Summary
- Refresh web dashboard every minute by fetching recent 48h data from a new `/data` endpoint
- Update sensor loop to sample once per minute and expose JSON API for chart refreshes
- Include disk usage and uptime details in the periodic Telegram text summary

## Testing
- `python -m py_compile apps/sht20/sht20_ubuntu64.py`


------
https://chatgpt.com/codex/tasks/task_e_6894b5cbaba08331b49c1d376a7583dc