### PR TITLE
feat: log motion detections and send dated mosaics

### DIFF
--- a/apps/camera/motion/tile_send/send_person_mosaic.py
+++ b/apps/camera/motion/tile_send/send_person_mosaic.py
@@ -1,48 +1,43 @@
 #!/usr/bin/env python3
-"""Monitor motion images, detect people, create mosaics and send via telegram.
+"""Detect people in recent motion images and report to InfluxDB.
 
-The script waits for five new images to appear in ``/var/lib/motion``. Once the
-threshold is met, it collects the next sixteen images, runs a person detection
-model on them and stores the counts to InfluxDB. A mosaic of the images is
-generated along with two graphs for the last 48 hours: number of detected
-people and remaining HDD space. All artefacts are then sent using
-``telegram-send``. Progress for long running operations is displayed with
-``rich``.
+The script scans ``/var/lib/motion`` for JPG images created within the last
+30 minutes. Each image is analysed with a YOLO model and the number of detected
+persons is written to InfluxDB using the timestamp encoded in the file name. A
+count of zero is recorded when no person is found. If no new images are
+available the script exits quietly. When at least one image in the period
+contains a person, a graph of the last 48 hours of person counts is rendered and
+sent via ``telegram-send``.
 
-When ``--date YYYY-MM-DD`` is supplied, the script instead processes all images
-from that day, sending mosaics of the photos in 4x4 batches.
+When ``--date YYYY-MM-DD`` is provided, the script queries InfluxDB for times on
+that date where a person was detected and sends mosaics of the corresponding
+images via telegram, annotating each tile with its capture time.
 """
 
 from __future__ import annotations
 
+import argparse
 import os
+import re
 import subprocess
 import time
-import shutil
-import argparse
-from datetime import datetime, timedelta, date
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Dict, Iterable, List
 
-try:
-    import psutil
-except ImportError:  # pragma: no cover - optional dependency
-    psutil = None
-
 import matplotlib.pyplot as plt
 from PIL import Image, ImageDraw, ImageFont
+from influxdb import InfluxDBClient
 from rich.console import Console
 from rich.progress import Progress
-# use the classic influxdb client instead of raw HTTP requests
-from influxdb import InfluxDBClient
-
 from ultralytics import YOLO
 
+console = Console()
+
+
+# Paths and configuration ----------------------------------------------------
 MOTION_DIR = Path("/var/lib/motion")
-OUTPUT_MOSAIC = Path("/tmp/motion_mosaic.jpg")
-PERSON_MOSAIC = Path("/tmp/person_mosaic.jpg")
 PEOPLE_GRAPH = Path("/tmp/person_count.png")
-DISK_GRAPH = Path("/tmp/disk_free.png")
 
 INFLUX_HOST = os.getenv("INFLUX_HOST", "localhost")
 INFLUX_PORT = int(os.getenv("INFLUX_PORT", "8086"))
@@ -50,23 +45,8 @@ INFLUX_USER = os.getenv("INFLUX_USER", "admin")
 INFLUX_PASSWORD = os.getenv("INFLUX_PASSWORD", "admin")
 INFLUX_DB = os.getenv("INFLUX_DB", "motion")
 
-console = Console()
 
-
-def print_system_usage(tag: str = "", disk_path: str = str(MOTION_DIR)) -> None:
-    """Print current system CPU, RAM and disk usage with an optional tag."""
-    if psutil is None:
-        console.print(f"{tag}CPU/RAM/Disk usage unavailable (psutil missing)")
-        return
-    cpu = psutil.cpu_percent(interval=None)
-    mem = psutil.virtual_memory()
-    usage = psutil.disk_usage(disk_path)
-    free_gb = usage.free / (1024 ** 3)
-    console.print(
-        f"{tag}CPU: {cpu:.1f}% | RAM: {mem.percent:.1f}% | Disk Free: {free_gb:.1f} GB"
-    )
-
-
+# Utility functions ----------------------------------------------------------
 def ensure_influx_running() -> None:
     """Start the InfluxDB service if it is not running."""
     running = subprocess.run(
@@ -75,189 +55,51 @@ def ensure_influx_running() -> None:
         stderr=subprocess.DEVNULL,
     ).returncode
     if running != 0:
-        console.print("InfluxDB not running, attempting to start...")
-        started = subprocess.run(
+        subprocess.run(
             ["systemctl", "start", "influxdb"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-        ).returncode
-        if started != 0:
-            subprocess.Popen(
-                ["influxd"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
+        )
         time.sleep(5)
 
 
 def ensure_database(client: InfluxDBClient, name: str) -> None:
-    """Create the given database in InfluxDB if it doesn't exist."""
-    try:
-        existing = {db["name"] for db in client.get_list_database()}
-        if name not in existing:
-            client.create_database(name)
-    except Exception as exc:  # pragma: no cover - best effort
-        console.print(f"Failed to verify/create database {name}: {exc}")
+    """Create database ``name`` in InfluxDB if it does not exist."""
+    existing = {db["name"] for db in client.get_list_database()}
+    if name not in existing:
+        client.create_database(name)
 
 
+def timestamp_from_filename(path: Path) -> datetime:
+    """Return ``datetime`` encoded in ``path`` or fall back to ``mtime``."""
+    match = re.search(r"(\d{8})[_-](\d{6})", path.name)
+    if match:
+        dt_str = match.group(1) + match.group(2)
+        try:
+            return datetime.strptime(dt_str, "%Y%m%d%H%M%S")
+        except ValueError:
+            pass
+    return datetime.fromtimestamp(path.stat().st_mtime)
 
-def _images_in_range(start: datetime, end: datetime) -> List[Path]:
-    """Return image paths whose mtime lies between ``start`` and ``end``."""
-    images: List[Path] = []
-    exts = {".jpg", ".jpeg", ".png"}
+
+def recent_images(minutes: int = 30) -> Dict[Path, datetime]:
+    """Return mapping of images within the last ``minutes`` to their timestamp."""
+    cutoff = datetime.now() - timedelta(minutes=minutes)
+    images: Dict[Path, datetime] = {}
     for entry in os.scandir(MOTION_DIR):
         if not entry.is_file():
             continue
-        if not entry.name.lower().endswith(tuple(exts)):
+        if not entry.name.lower().endswith((".jpg", ".jpeg")):
             continue
-        mtime = datetime.fromtimestamp(entry.stat().st_mtime)
-        if start <= mtime <= end:
-            images.append(Path(entry.path))
-    return sorted(images, key=lambda p: p.stat().st_mtime, reverse=True)
-
-
-def _images_since(start: datetime) -> List[Path]:
-    """Return images newer than ``start`` limited to the last four days."""
-    now = datetime.now()
-    cutoff = max(start, now - timedelta(days=4))
-    return _images_in_range(cutoff, now)
-
-
-def images_for_day(day: date) -> List[Path]:
-    """Return all images for the given ``day`` (00:00-23:59)."""
-    start = datetime.combine(day, datetime.min.time())
-    end = start + timedelta(days=1)
-    return _images_in_range(start, end)
-
-
-def wait_for_images(start: datetime, count: int) -> List[Path]:
-    """Block until ``count`` images exist after ``start``."""
-    while True:
-        imgs = _images_since(start)
-        if len(imgs) >= count:
-            return imgs[:count]
-        time.sleep(2)
-
-
-def log_images(image_paths: Iterable[Path]) -> None:
-    """Print paths of images being processed with progress."""
-    paths = list(image_paths)
-    with Progress() as progress:
-        task = progress.add_task("Images", total=len(paths))
-        for p in paths:
-            progress.print(str(p))
-            progress.advance(task)
-
-
-def create_mosaic(
-    image_paths: Iterable[Path], output_path: Path, cols: int = 4, rows: int = 4
-) -> Path:
-    """Assemble images into a mosaic of ``cols`` by ``rows`` tiles.
-
-    The earliest timestamp among the images is rendered onto the mosaic.
-    """
-    paths = list(image_paths)[: cols * rows]
-    if not paths:
-        raise ValueError("No images provided for mosaic")
-    imgs = [Image.open(p) for p in paths]
-
-    w, h = imgs[0].size
-    mosaic = Image.new("RGB", (cols * w, rows * h))
-
-    with Progress() as progress:
-        task = progress.add_task("Assembling mosaic", total=len(imgs))
-        for idx, (img, path) in enumerate(zip(imgs, paths)):
-            x = (idx % cols) * w
-            y = (idx // cols) * h
-            mosaic.paste(img, (x, y))
-            progress.print(str(path))
-
-            progress.advance(task)
-
-    # annotate with the earliest timestamp of the included images
-    earliest = min(paths, key=lambda p: p.stat().st_mtime).stat().st_mtime
-    time_text = datetime.fromtimestamp(earliest).strftime("%Y-%m-%d %H:%M:%S")
-    draw = ImageDraw.Draw(mosaic)
-    try:
-        font = ImageFont.truetype(
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 24
-        )
-    except OSError:  # pragma: no cover - font may be missing
-        font = ImageFont.load_default()
-    x, y = 10, 10
-    # draw black outline for readability
-    for dx in (-1, 0, 1):
-        for dy in (-1, 0, 1):
-            if dx or dy:
-                draw.text((x + dx, y + dy), time_text, font=font, fill="black")
-    draw.text((x, y), time_text, font=font, fill="white")
-
-    mosaic.save(output_path)
-    return output_path
-
-
-def select_person_images(
-    image_paths: Iterable[Path],
-    counts: Dict[Path, int],
-    min_interval: int = 60,
-    limit: int = 16,
-) -> List[Path]:
-    """Return up to ``limit`` images with people spaced ``min_interval`` seconds apart."""
-    paths = sorted(image_paths, key=lambda p: p.stat().st_mtime)
-    selected: List[Path] = []
-    last_time: float | None = None
-    for path in paths:
-        if counts.get(path, 0) <= 0:
-            continue
-        mtime = path.stat().st_mtime
-        if last_time is None or mtime - last_time >= min_interval:
-            selected.append(path)
-            last_time = mtime
-        if len(selected) >= limit:
-            break
-    return selected
-
-
-def create_timed_mosaic(
-    image_paths: Iterable[Path], output_path: Path, cols: int = 4, rows: int = 4
-) -> Path:
-    """Create a mosaic annotating each tile with its capture time."""
-    paths = list(image_paths)[: cols * rows]
-    if not paths:
-        raise ValueError("No images provided for mosaic")
-    imgs = [Image.open(p) for p in paths]
-    w, h = imgs[0].size
-    mosaic = Image.new("RGB", (cols * w, rows * h))
-
-    try:
-        font = ImageFont.truetype(
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 24
-        )
-    except OSError:  # pragma: no cover - font may be missing
-        font = ImageFont.load_default()
-
-    with Progress() as progress:
-        task = progress.add_task("Assembling mosaic", total=len(imgs))
-        for idx, (img, path) in enumerate(zip(imgs, paths)):
-            x = (idx % cols) * w
-            y = (idx // cols) * h
-            mosaic.paste(img, (x, y))
-            mtime = datetime.fromtimestamp(path.stat().st_mtime)
-            time_text = mtime.strftime("%Y-%m-%d %H:%M")
-            draw = ImageDraw.Draw(mosaic)
-            for dx in (-1, 0, 1):
-                for dy in (-1, 0, 1):
-                    if dx or dy:
-                        draw.text((x + 10 + dx, y + 10 + dy), time_text, font=font, fill="black")
-            draw.text((x + 10, y + 10), time_text, font=font, fill="white")
-            progress.print(str(path))
-            progress.advance(task)
-
-    mosaic.save(output_path)
-    return output_path
+        path = Path(entry.path)
+        ts = timestamp_from_filename(path)
+        if ts >= cutoff:
+            images[path] = ts
+    return images
 
 
 def detect_people(model: YOLO, image_paths: Iterable[Path]) -> Dict[Path, int]:
+    """Return number of detected persons for each image."""
     paths = list(image_paths)
     counts: Dict[Path, int] = {}
     with Progress() as progress:
@@ -267,19 +109,22 @@ def detect_people(model: YOLO, image_paths: Iterable[Path]) -> Dict[Path, int]:
             persons = sum(1 for c in results[0].boxes.cls if int(c) == 0)
             counts[path] = persons
             progress.print(str(path))
-
             progress.advance(task)
     return counts
 
 
-def write_counts(client: InfluxDBClient, counts: Dict[Path, int]) -> None:
+def write_counts(
+    client: InfluxDBClient, counts: Dict[Path, int], times: Dict[Path, datetime]
+) -> None:
+    """Store person counts in InfluxDB using supplied timestamps."""
     points = []
     for path, num in counts.items():
+        ts = times.get(path, datetime.utcfromtimestamp(path.stat().st_mtime))
         points.append(
             {
                 "measurement": "person_count",
                 "tags": {"source": "motion"},
-                "time": datetime.utcfromtimestamp(path.stat().st_mtime).isoformat() + "Z",
+                "time": ts.isoformat() + "Z",
                 "fields": {"count": num},
             }
         )
@@ -287,37 +132,24 @@ def write_counts(client: InfluxDBClient, counts: Dict[Path, int]) -> None:
         client.write_points(points)
 
 
-def write_disk_free(client: InfluxDBClient) -> None:
-    free = shutil.disk_usage("/").free
-    point = {
-        "measurement": "disk_free",
-        "time": datetime.utcnow().isoformat() + "Z",
-        "fields": {"bytes": free},
-    }
-    client.write_points([point])
-
-
-def generate_graph(
-    client: InfluxDBClient, measurement: str, field: str, output: Path
-) -> Path:
+def generate_graph(client: InfluxDBClient, output: Path) -> Path:
+    """Create a 48 hour graph of person counts."""
     query = (
-        f'SELECT "{field}" FROM "{measurement}" '
-        f'WHERE time > now() - 48h'
+        'SELECT "count" FROM "person_count" WHERE time > now() - 48h'
     )
     result = client.query(query)
-    points = list(result.get_points(measurement=measurement))
+    points = list(result.get_points(measurement="person_count"))
 
-    times: List[datetime] = []
-    values: List[float] = []
+    times: list[datetime] = []
+    values: list[float] = []
     for p in points:
         times.append(datetime.fromisoformat(p["time"].replace("Z", "+00:00")))
-        values.append(p[field])
-
+        values.append(p["count"])
 
     if times and values:
         plt.figure()
         plt.plot(times, values, "o", linestyle="none")
-        plt.title(measurement)
+        plt.title("person_count")
         plt.xlabel("time")
         plt.ylabel("value")
         plt.grid(True, linestyle="--", linewidth=0.5)
@@ -327,76 +159,114 @@ def generate_graph(
     return output
 
 
-def send_via_telegram(paths: Iterable[Path], delay: float = 1.0) -> None:
+def send_via_telegram(paths: Iterable[Path]) -> None:
+    """Send files via telegram-send."""
     for path in paths:
         subprocess.run(["telegram-send", "-i", str(path)], check=True)
-        time.sleep(delay)
+
+
+def query_person_times(client: InfluxDBClient, day: date) -> List[datetime]:
+    """Return times on ``day`` where a person was detected."""
+    start = datetime.combine(day, datetime.min.time())
+    end = start + timedelta(days=1)
+    query = (
+        f"SELECT \"count\" FROM \"person_count\" "
+        f"WHERE time >= '{start.isoformat()}Z' AND time < '{end.isoformat()}Z' "
+        "AND \"count\" > 0"
+    )
+    result = client.query(query)
+    return [
+        datetime.fromisoformat(p["time"].replace("Z", "+00:00"))
+        for p in result.get_points(measurement="person_count")
+    ]
+
+
+def images_for_times(times: Iterable[datetime]) -> List[Path]:
+    """Return image files matching the given timestamps."""
+    images: List[Path] = []
+    for ts in times:
+        stamp = ts.strftime("%Y%m%d%H%M%S")
+        images.extend(sorted(MOTION_DIR.glob(f"*{stamp}*.jpg")))
+        images.extend(sorted(MOTION_DIR.glob(f"*{stamp}*.jpeg")))
+    return images
+
+
+def create_mosaic_with_times(
+    image_paths: Iterable[Path], output: Path, cols: int = 4, rows: int = 4
+) -> Path:
+    """Create a mosaic annotating each tile with its capture time."""
+    paths = list(image_paths)[: cols * rows]
+    if not paths:
+        raise ValueError("No images for mosaic")
+    imgs = [Image.open(p) for p in paths]
+    w, h = imgs[0].size
+    mosaic = Image.new("RGB", (cols * w, rows * h))
+    try:
+        font = ImageFont.truetype(
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 24
+        )
+    except OSError:  # pragma: no cover - font may be missing
+        font = ImageFont.load_default()
+
+    for idx, (img, path) in enumerate(zip(imgs, paths)):
+        ts = timestamp_from_filename(path)
+        text = ts.strftime("%Y-%m-%d %H:%M:%S")
+        draw = ImageDraw.Draw(img)
+        x, y = 10, 10
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                if dx or dy:
+                    draw.text((x + dx, y + dy), text, font=font, fill="black")
+        draw.text((x, y), text, font=font, fill="white")
+        x0 = (idx % cols) * w
+        y0 = (idx // cols) * h
+        mosaic.paste(img, (x0, y0))
+
+    mosaic.save(output)
+    return output
+
+
+def process_date(day: date) -> None:
+    """Send mosaics of all person detections for ``day`` via telegram."""
+    ensure_influx_running()
+    client = InfluxDBClient(
+        host=INFLUX_HOST,
+        port=INFLUX_PORT,
+        username=INFLUX_USER or None,
+        password=INFLUX_PASSWORD or None,
+    )
+    ensure_database(client, INFLUX_DB)
+    client.switch_database(INFLUX_DB)
+    times = query_person_times(client, day)
+    client.close()
+    if not times:
+        return
+
+    images = images_for_times(times)
+    for idx in range(0, len(images), 16):
+        group = images[idx : idx + 16]
+        out = Path(f"/tmp/person_mosaic_{idx//16 + 1}.jpg")
+        create_mosaic_with_times(group, out)
+        send_via_telegram([out])
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--date", help="YYYY-MM-DD to mosaic instead of live feed")
+    parser.add_argument("--date", help="Process images for given date (YYYY-MM-DD)")
     args = parser.parse_args()
 
-    perf_start = time.perf_counter()
-    print_system_usage("Start ")
-
     if args.date:
-        target_day = datetime.strptime(args.date, "%Y-%m-%d").date()
-        images = images_for_day(target_day)
-        if not images:
-            console.print(f"No images found for {args.date}")
-            print_system_usage("End ")
-            console.print(f"Elapsed time: {time.perf_counter() - perf_start:.2f}s")
-            return
-
-        model = YOLO("yolov8n.pt")
-        ensure_influx_running()
-        client = InfluxDBClient(
-            host=INFLUX_HOST,
-            port=INFLUX_PORT,
-            username=INFLUX_USER or None,
-            password=INFLUX_PASSWORD or None,
-        )
-        ensure_database(client, INFLUX_DB)
-        client.switch_database(INFLUX_DB)
-
-        for idx in range(0, len(images), 16):
-            batch = images[idx : idx + 16]
-            log_images(batch)
-            counts = detect_people(model, batch)
-            write_counts(client, counts)
-            mosaic_path = OUTPUT_MOSAIC.with_name(f"motion_mosaic_{idx//16}.jpg")
-            create_mosaic(batch, mosaic_path)
-            person_imgs = select_person_images(batch, counts)
-            to_send: List[Path] = [mosaic_path]
-            if person_imgs:
-                person_path = PERSON_MOSAIC.with_name(
-                    f"person_mosaic_{idx//16}.jpg"
-                )
-                create_timed_mosaic(person_imgs, person_path)
-                to_send.append(person_path)
-            send_via_telegram(to_send)
-
-        #write_disk_free(client)
-        #generate_graph(client, "person_count", "count", PEOPLE_GRAPH)
-        #generate_graph(client, "disk_free", "bytes", DISK_GRAPH)
-        #send_via_telegram([PEOPLE_GRAPH, DISK_GRAPH])
-        client.close()
-
-        print_system_usage("End ")
-        console.print(f"Elapsed time: {time.perf_counter() - perf_start:.2f}s")
+        day = datetime.strptime(args.date, "%Y-%m-%d").date()
+        process_date(day)
         return
 
-    start_time = datetime.now()
-    #wait_for_images(start_time, 5)  # wait until 5 images appear
-    trigger = datetime.now()
-    images = wait_for_images(trigger, 16)
-
-    log_images(images)
+    start_perf = time.perf_counter()
+    recent = recent_images(30)
+    if not recent:
+        return
 
     model = YOLO("yolov8n.pt")
-    people_counts = detect_people(model, images)
+    counts = detect_people(model, recent.keys())
 
     ensure_influx_running()
     client = InfluxDBClient(
@@ -407,24 +277,15 @@ def main() -> None:
     )
     ensure_database(client, INFLUX_DB)
     client.switch_database(INFLUX_DB)
-    #write_counts(client, people_counts)
-    #write_disk_free(client)
-    #generate_graph(client, "person_count", "count", PEOPLE_GRAPH)
-    #generate_graph(client, "disk_free", "bytes", DISK_GRAPH)
+    write_counts(client, counts, recent)
+
+    any_person = any(num > 0 for num in counts.values())
+    if any_person:
+        generate_graph(client, PEOPLE_GRAPH)
+        send_via_telegram([PEOPLE_GRAPH])
+
     client.close()
-
-    mosaic_path = create_mosaic(images, OUTPUT_MOSAIC)
-    person_images = select_person_images(images, people_counts)
-    paths_to_send: List[Path] = [mosaic_path]
-    if person_images:
-        person_mosaic = create_timed_mosaic(person_images, PERSON_MOSAIC)
-        paths_to_send.append(person_mosaic)
-    #paths_to_send.extend([PEOPLE_GRAPH, DISK_GRAPH])
-
-    send_via_telegram(paths_to_send)
-
-    print_system_usage("End ")
-    console.print(f"Elapsed time: {time.perf_counter() - perf_start:.2f}s")
+    console.print(f"Elapsed time: {time.perf_counter() - start_perf:.2f}s")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- detect and log person counts from recent motion images
- query detections by date and send 4x4 mosaics with per-image timestamps via telegram

## Testing
- `python -m py_compile apps/camera/motion/tile_send/send_person_mosaic.py`


------
https://chatgpt.com/codex/tasks/task_e_6899f55910708331aaa7f2ab77b0b267