### PR TITLE
Add fallback HTTP download for file_list.json

### DIFF
--- a/apps/camera/ocr_name_card/download_file_list.py
+++ b/apps/camera/ocr_name_card/download_file_list.py
@@ -1,9 +1,11 @@
+import argparse
 import json
-from webdav3.client import Client
 
 
 def download_file_list(config_path: str = "nocommit_url2.ini") -> None:
     """Read WebDAV credentials from a JSON config and download file_list.json."""
+    from webdav3.client import Client
+
     with open(config_path, 'r', encoding='utf-8') as f:
         config = json.load(f)
 
@@ -34,8 +36,57 @@ def download_file_list(config_path: str = "nocommit_url2.ini") -> None:
         print(f"{remote_path} not found on server")
         return
 
-    client.download_sync(remote_path=remote_path, local_path=local_path)
+    try:
+        import requests
+
+        client.download_sync(remote_path=remote_path, local_path=local_path)
+    except KeyError:
+        url = f"{options['webdav_hostname'].rstrip('/')}{remote_path}"
+        with requests.get(
+            url,
+            auth=(options['webdav_login'], options['webdav_password']),
+            stream=True,
+            verify=client.verify,
+        ) as r:
+            r.raise_for_status()
+            with open(local_path, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+    except ImportError:
+        print('requests library is required for download')
+
+
+def check_ctime(local_path: str = './file_list.json') -> None:
+    """Print oldest and newest ctime values from file_list.json."""
+    try:
+        with open(local_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        print(f"{local_path} not found")
+        return
+
+    items = data.values() if isinstance(data, dict) else data
+    ctimes = []
+    for item in items:
+        if isinstance(item, dict) and 'ctime' in item:
+            ctimes.append(item['ctime'])
+
+    if not ctimes:
+        print('No ctime fields found')
+        return
+
+    print(f"Oldest ctime: {min(ctimes)}")
+    print(f"Newest ctime: {max(ctimes)}")
 
 
 if __name__ == '__main__':
-    download_file_list()
+    parser = argparse.ArgumentParser(description='Download or check file_list.json')
+    parser.add_argument('--check', action='store_true', help='show ctime range instead of downloading')
+    parser.add_argument('--config', default='nocommit_url2.ini', help='path to JSON config file')
+    args = parser.parse_args()
+
+    if args.check:
+        check_ctime()
+    else:
+        download_file_list(config_path=args.config)


### PR DESCRIPTION
## Summary
- Lazily import WebDAV and requests clients to allow running checks without WebDAV deps
- Add `--check` option to report oldest and newest `ctime` values in `file_list.json`

## Testing
- `python -m py_compile apps/camera/ocr_name_card/download_file_list.py`
- `python apps/camera/ocr_name_card/download_file_list.py --check`


------
https://chatgpt.com/codex/tasks/task_e_68a5f7ce4f7c833193c3f3e9c96e87de