### PR TITLE
Use nocommit.ini for Bookstack backup credentials

### DIFF
--- a/apps/bookstack/backup_bookstack.sh
+++ b/apps/bookstack/backup_bookstack.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="$SCRIPT_DIR/nocommit.ini"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Config file not found: $CONFIG_FILE"
+  exit 1
+fi
+
+DB=$(awk -F '=' '/^db[ \t]*=/ {print $2}' "$CONFIG_FILE" | tr -d ' \r\n')
+ID=$(awk -F '=' '/^id[ \t]*=/ {print $2}' "$CONFIG_FILE" | tr -d ' \r\n')
+PASSWORD=$(awk -F '=' '/^password[ \t]*=/ {print $2}' "$CONFIG_FILE" | tr -d ' \r\n')
+
+if [[ -z "$DB" || -z "$ID" || -z "$PASSWORD" ]]; then
+  echo "db, id or password missing in $CONFIG_FILE"
+  exit 1
+fi
+
 # 현재 날짜/시간으로 백업 디렉터리 생성
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 BACKUP_DIR="$PWD/bookstack_backup_$TIMESTAMP"
@@ -6,7 +24,7 @@ mkdir -p "$BACKUP_DIR"
 
 # 1) 데이터베이스 백업 (컨테이너 이름: bookstack_db)
 docker exec bookstack_db \
-  mysqldump -u bookstack -p'비밀번호' bookstack \
+  mysqldump -u "$ID" -p"$PASSWORD" "$DB" \
   > "$BACKUP_DIR/bookstack.sql"
 
 # 2) 업로드 파일 백업 (컨테이너 이름: bookstack_app)

--- a/apps/bookstack/readme.md
+++ b/apps/bookstack/readme.md
@@ -4,7 +4,16 @@
 - .env file should have
   - APP_URL= http://192.168.0.100:6875
  
-- admin@admin.com password 
+- admin@admin.com password
 
 ### Backup
 
+`backup_bookstack.sh` 스크립트는 `nocommit.ini` 파일에 저장된 데이터베이스 정보를 사용합니다. 예시는 다음과 같습니다.
+
+```
+db=bookstack
+id=bookstack
+password=your_password
+```
+
+`nocommit.ini` 파일은 버전에 포함되지 않으므로 필요에 따라 직접 생성해야 합니다.


### PR DESCRIPTION
## Summary
- load DB name, user, and password from `nocommit.ini` in Bookstack backup script
- document the required `nocommit.ini` file and its format

## Testing
- `bash -n apps/bookstack/backup_bookstack.sh`
- `shellcheck --version` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a93d67fc14833183a2c0e9b2ac87b4