### PR TITLE
Add configurable fan duty cycle for piroman5

### DIFF
--- a/apps/oled_piroman5/README.md
+++ b/apps/oled_piroman5/README.md
@@ -1,6 +1,6 @@
 # OLED IP Display
 
-Simple example using **piroman5** Raspberry Pi OLED driver (based on `luma.oled`) to show the current IP address and timestamp on a small OLED screen. The fan on BCM pin 18 of the piroman5 max board is automatically controlled based on the CPU temperature.
+Simple example using **piroman5** Raspberry Pi OLED driver (based on `luma.oled`) to show the current IP address and timestamp on a small OLED screen. The fan on BCM pin 18 of the piroman5 max board is automatically controlled based on the CPU temperature and can be limited to a percentage of the minute with the ``--fan-duty`` option.
 
 
 ## Installation
@@ -22,5 +22,13 @@ Add an entry to ``crontab`` so the script runs every minute:
 * * * * * /usr/bin/python3 /path/to/ip_display.py
 ```
 
-Each run updates the OLED with the current IP address and the date/time (including seconds). The fan is powered on when the script starts. It remains on whenever the CPU temperature is 50 °C or higher and turns off once the temperature falls below that threshold.
+To run the fan for less than the full minute when the CPU is cool, pass a percentage with ``--fan-duty`` (default is ``100``):
+
+```bash
+* * * * * /usr/bin/python3 /path/to/ip_display.py --fan-duty 75
+```
+
+Each run updates the OLED with the current IP address and the date/time (including seconds). The fan is powered on when the script starts. It remains on whenever the CPU temperature is 50 °C or higher and, when cooler, runs only for the specified portion of the minute.
+
+The display also shows the current fan duty setting as ``Duty: <percentage>/60s`` on the last line.
 


### PR DESCRIPTION
## Summary
- allow ip_display.py to accept a `--fan-duty` percentage argument (default 100)
- display the current fan duty cycle on the OLED (e.g. `Duty: 75%/60s`)
- document fan-duty usage and display line in OLED IP Display README

## Testing
- `pip install luma.oled luma.core` *(fails: Cannot connect to proxy, 403 Forbidden)*
- `python apps/oled_piroman5/ip_display.py --help` *(fails: ModuleNotFoundError: No module named 'luma')*
- `python -m py_compile apps/oled_piroman5/ip_display.py`


------
https://chatgpt.com/codex/tasks/task_e_68abb4166b1c8331bd7c40e5f448ccbf