### PR TITLE
Add configurable fan duty cycle for piroman5

### DIFF
--- a/apps/oled_piroman5/README.md
+++ b/apps/oled_piroman5/README.md
@@ -1,6 +1,6 @@
 # OLED IP Display
 
-Simple example using **piroman5** Raspberry Pi OLED driver (based on `luma.oled`) to show the current IP address and timestamp on a small OLED screen. The fan on BCM pin 18 of the piroman5 max board is automatically controlled based on the CPU temperature.
+Simple example using **piroman5** Raspberry Pi OLED driver (based on `luma.oled`) to show the current IP address and timestamp on a small OLED screen. The fan on BCM pin 18 of the piroman5 max board is automatically controlled based on the CPU temperature and can be limited to a percentage of a two-minute interval with the ``--fan-duty`` option.
 
 
 ## Installation
@@ -16,11 +16,23 @@ sudo apt install libgpiod-dev
 
 ## Running
 
-Add an entry to ``crontab`` so the script runs every minute:
+Add an entry to ``crontab`` so the script runs every two minutes:
 
 ```bash
-* * * * * /usr/bin/python3 /path/to/ip_display.py
+*/2 * * * * /usr/bin/python3 /path/to/ip_display.py
 ```
 
-Each run updates the OLED with the current IP address and the date/time (including seconds). The fan is powered on when the script starts. It remains on whenever the CPU temperature is 50 °C or higher and turns off once the temperature falls below that threshold.
+To run the fan for less than the full two minutes when the CPU is cool, pass a percentage with ``--fan-duty`` (default is ``100``):
+
+```bash
+*/2 * * * * /usr/bin/python3 /path/to/ip_display.py --fan-duty 75
+```
+
+Each run updates the OLED with the current IP address and the date/time (including seconds). The fan is powered on when the script starts. It remains on whenever the CPU temperature is 50 °C or higher and, when cooler, runs only for the specified portion of the two-minute cycle.
+
+The display's last line shows the configured fan duty and updates every five seconds with the remaining time in the two-minute interval, e.g. ``Duty: 75%/120s L115s``.
+
+The line above the duty information shows the current CO₂ concentration read from a serial sensor (e.g. ``CO2 450ppm``).
+
+At startup the script lists all detected USB serial ports and logs the one used for the CO₂ sensor connection.
 

--- a/apps/oled_piroman5/requirements.txt
+++ b/apps/oled_piroman5/requirements.txt
@@ -1,4 +1,5 @@
 luma.oled
+luma.core
 Pillow
 gpiozero
-lume.core
+pyserial


### PR DESCRIPTION
## Summary
- allow ip_display.py to accept a `--fan-duty` percentage argument (default 100)
- show CO₂ sensor ppm on the OLED alongside network, time, CPU temp, and fan status
- document the CO₂ line and add pyserial to requirements while fixing luma.core entry
- display the current fan duty and remaining time in the two-minute cycle on the last line
- prevent dynamic console updates from erasing CO₂ sensor debug output by switching to line-based logging
- enumerate available USB serial ports and log the one used for the CO₂ sensor

## Testing
- `pip install luma.oled luma.core` *(fails: Could not find a version that satisfies the requirement luma.oled)*
- `python apps/oled_piroman5/ip_display.py --help` *(fails: ModuleNotFoundError: No module named 'berepi_logger')*
- `python -m py_compile apps/oled_piroman5/ip_display.py`


------
https://chatgpt.com/codex/tasks/task_e_68abb4166b1c8331bd7c40e5f448ccbf