### PR TITLE
Add configurable fan duty cycle for piroman5

### DIFF
--- a/apps/oled_piroman5/README.md
+++ b/apps/oled_piroman5/README.md
@@ -1,6 +1,6 @@
 # OLED IP Display
 
-Simple example using **piroman5** Raspberry Pi OLED driver (based on `luma.oled`) to show the current IP address and timestamp on a small OLED screen. The fan on BCM pin 18 of the piroman5 max board is automatically controlled based on the CPU temperature.
+Simple example using **piroman5** Raspberry Pi OLED driver (based on `luma.oled`) to show the current IP address and timestamp on a small OLED screen. The fan on BCM pin 18 of the piroman5 max board is automatically controlled based on the CPU temperature and can be limited to a percentage of a two-minute interval with the ``--fan-duty`` option.
 
 
 ## Installation
@@ -16,11 +16,35 @@ sudo apt install libgpiod-dev
 
 ## Running
 
-Add an entry to ``crontab`` so the script runs every minute:
+Add an entry to ``crontab`` so the script runs every two minutes:
 
 ```bash
-* * * * * /usr/bin/python3 /path/to/ip_display.py
+*/2 * * * * /usr/bin/python3 /path/to/ip_display.py
 ```
 
-Each run updates the OLED with the current IP address and the date/time (including seconds). The fan is powered on when the script starts. It remains on whenever the CPU temperature is 50 °C or higher and turns off once the temperature falls below that threshold.
+To run the fan for less than the full two minutes when the CPU is cool, pass a percentage with ``--fan-duty`` (default is ``100``):
+
+```bash
+*/2 * * * * /usr/bin/python3 /path/to/ip_display.py --fan-duty 75
+```
+
+Each run updates the OLED with the current IP address and the date/time (including seconds). The fan is powered on when the script starts. It remains on whenever the CPU temperature is 50 °C or higher and, when cooler, runs only for the specified portion of the two-minute cycle.
+
+The display's last line shows the configured fan duty and updates every five seconds with the remaining time in the two-minute interval, e.g. ``Duty: 75%/120s L115s``.
+
+The line above the duty information shows the current CO₂ concentration read from a serial sensor (e.g. ``CO2 450ppm``).
+
+At startup the script lists all detected USB serial ports and logs the one used for the CO₂ sensor connection.
+
+Two helper functions, ``cpu_fan_on()`` and ``led_fan_on()``, are available if you need to manually activate the CPU fan or its RGB LED fan from other scripts.
+
+For a standalone utility that simply powers the fan and its LEDs on, run
+``fan_on.py`` in this directory:
+
+```bash
+python3 fan_on.py
+```
+
+The script leaves the fan and LEDs running after it exits so you can use it
+for quick manual testing.
 

--- a/apps/oled_piroman5/fan_on.py
+++ b/apps/oled_piroman5/fan_on.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Simple helper to activate the CPU cooling fan and its RGB LEDs.
+
+Running this script will turn on the fan connected to BCM pin 18 and
+light the two RGB LED outputs on pins 5 and 6. The state persists after
+exit so the fan and LEDs stay on.
+"""
+
+import atexit
+from gpiozero import OutputDevice, Device
+
+FAN_PIN = 18
+RGBFAN_PIN = (5, 6)
+
+
+def cpu_fan_on(pin=FAN_PIN):
+    """Activate the CPU cooling fan and return its device."""
+    fan = OutputDevice(pin, active_high=True)
+    fan.on()
+    return fan
+
+
+def led_fan_on(pins=RGBFAN_PIN):
+    """Activate the LED fan outputs and return their devices."""
+    leds = [OutputDevice(pin, active_high=True) for pin in pins]
+    for led in leds:
+        led.on()
+    return leds
+
+
+def main():
+    """Turn on the CPU fan and RGB LED fan."""
+    if hasattr(Device, "_shutdown"):
+        try:
+            atexit.unregister(Device._shutdown)
+        except Exception:
+            pass
+    cpu_fan_on()
+    led_fan_on()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/oled_piroman5/ip_display.py
+++ b/apps/oled_piroman5/ip_display.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Display IP address and time on the OLED using the piroman5 driver.
 
-This script is designed to be called from ``cron`` once per minute.
+This script is designed to be called from ``cron`` once every two minutes.
 It updates the OLED with the current IPv4 address and timestamp, and
-controls the cooling fan on the piroman5 max board when the CPU
-temperature exceeds ``50°C``.
+controls the cooling fan on the piroman5 max board. By default the
+fan runs continuously, but a different duty cycle (e.g. 75 or 50) may
+be specified via ``--fan-duty`` to run the fan only for part of the
+two-minute interval when the CPU temperature is below ``50°C``.
 
 Dependencies can be installed with::
 
@@ -13,6 +15,18 @@ Dependencies can be installed with::
 
 from datetime import datetime
 import subprocess
+import argparse
+import serial
+import sys
+import time
+from serial.tools import list_ports
+
+BNAME = "/home/tinyos/devel_opment/"
+LOG_DIR = BNAME + "selfcloud/apps/log"
+
+sys.path.append(LOG_DIR)
+
+import berepi_logger
 
 # piroman5 OLED driver, built on luma.oled
 from luma.core.interface.serial import i2c
@@ -21,7 +35,6 @@ from luma.core.render import canvas
 from PIL import ImageFont
 import atexit
 from gpiozero import OutputDevice, CPUTemperature, Device
-import time
 from rich.console import Console
 
 # pin used to control the cooling fan on piroman5 max
@@ -44,8 +57,77 @@ def get_ip_address(interface="eth0"):
     return "0.0.0.0"
 
 
+def parse_args():
+    """Return parsed command line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Update the OLED and control the cooling fan once."
+    )
+    parser.add_argument(
+        "--fan-duty",
+        type=int,
+        default=100,
+        help=(
+            "Percentage of the two-minute cycle to run the fan when the CPU "
+            "temperature is below the threshold (0-100)."
+        ),
+    )
+    return parser.parse_args()
+
+
+def find_ppm(ins):
+    print("RAW string", ins)
+    stnum = 0
+    if ins[0] == 0xF1 and ins[1] == 0xF2 and ins[2] == 0x02:
+        stnum = ins[3] * 256 + ins[4]
+    else:
+        print("error in data")
+        return None
+    ret = stnum
+    print("...", stnum, "ppm")
+    return ret
+
+
+def pass2file(ins):
+    print("...logging...")
+    print(time.strftime("%Y-%m-%d %H:%M"))
+    logclass = berepi_logger.selfdatalogger()
+    logclass.set_logger("CO2_POC")
+    logclass.berelog("co2 ppm", str(ins), "CO2_POC ")
+    print("co2 ppm", str(ins), "CO2_POC ")
+
+
+def read_co2(op):
+    rq_str = b"\xF1\xF2\x01\x1C"
+    op.write(rq_str)
+    in_string = op.read(size=8)
+    ppm = find_ppm(in_string)
+    if ppm is None:
+        in_string = op.read(size=8)
+        ppm = find_ppm(in_string)
+    return ppm
+
+
+def cpu_fan_on(pin=FAN_PIN):
+    """Activate the CPU cooling fan and return its device."""
+    fan = OutputDevice(pin, active_high=True)
+    fan.on()
+    return fan
+
+
+def led_fan_on(pins=RGBFAN_PIN):
+    """Activate the LED fan outputs and return their devices."""
+    leds = [OutputDevice(pin, active_high=True) for pin in pins]
+    for led in leds:
+        led.on()
+    return leds
+
+
 def main():
     """Update the OLED and control the cooling fan once."""
+
+    args = parse_args()
+    args.fan_duty = max(0, min(args.fan_duty, 100))
 
     # Prevent gpiozero from resetting the pin states on exit so the fan
     # remains in the state we set. Older versions of gpiozero may not
@@ -65,62 +147,79 @@ def main():
         pass
 
 
-    fan = OutputDevice(FAN_PIN, active_high=True)
-    # Ensure the fan starts running when the program launches
-    fan.on()
-    rgb_leds = [OutputDevice(pin, active_high=True) for pin in RGBFAN_PIN]
-    rgb_leds[0].on()
-    rgb_leds[1].on()
+    fan = cpu_fan_on()
+    rgb_leds = led_fan_on()
     cpu = CPUTemperature()
     console = Console()
 
+    co2_port = None
+    try:
+        ports = [p.device for p in list_ports.comports()]
+        console.print(
+            "Connected USB ports: " + (", ".join(ports) if ports else "None")
+        )
+        port_name = "/dev/ttyUSB0"
+        if port_name not in ports and ports:
+            port_name = ports[0]
+        if port_name in ports:
+            console.print(f"Using CO2 sensor port: {port_name}")
+            co2_port = serial.Serial(port_name, baudrate=9600, rtscts=True)
+            time.sleep(3)
+    except Exception as exc:
+        console.print(f"CO2 sensor setup failed: {exc}")
 
 
-    # Determine IP address and current time
+
+    # Determine IP address once; update other values in the loop
     ip = get_ip_address("eth0")
-    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-    temp = cpu.temperature
-    if temp >= TEMP_THRESHOLD:
-        fan.on()
-    else:
-        fan.off()
-
-    fan_status = "ON" if fan.is_active else "OFF"
+    total_runtime = 120
+    fan_on_duration = total_runtime * args.fan_duty / 100
+    remaining = total_runtime
 
     # Initialize OLED display via I2C
     serial = i2c(port=1, address=0x3C)
     device = ssd1306(serial)
-
     font = ImageFont.load_default()
 
-    # Draw the information once. The display retains the last frame so
-    # the text remains visible after the program ends.
-    with canvas(device) as draw:
-        draw.text((0, 0), ip, font=font, fill=255)
-        draw.text((0, 16), now, font=font, fill=255)
-        draw.text((0, 32), f"CPU {temp:.1f}C F:{fan_status}", font=font, fill=255)
-
-    remaining = 60
     while remaining >= 0:
         temp = cpu.temperature
-        if temp >= TEMP_THRESHOLD:
+        if temp >= TEMP_THRESHOLD or remaining > total_runtime - fan_on_duration:
             fan.on()
         else:
             fan.off()
         fan_status = "ON" if fan.is_active else "OFF"
-        console.print(
+        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        co2_ppm = None
+        if co2_port:
+            try:
+                co2_ppm = read_co2(co2_port)
+                if co2_ppm is not None:
+                    pass2file(co2_ppm)
+            except Exception:
+                co2_ppm = None
+        co2_text = f"CO2 {co2_ppm}ppm" if co2_ppm is not None else "CO2 N/A"
+        with canvas(device) as draw:
+            draw.text((0, 0), ip, font=font, fill=255)
+            draw.text((0, 12), now, font=font, fill=255)
+            draw.text((0, 24), f"CPU {temp:.1f}C F:{fan_status}", font=font, fill=255)
+            draw.text((0, 36), co2_text, font=font, fill=255)
+            draw.text(
+                (0, 48),
+                f"Duty: {args.fan_duty}%/{int(total_runtime)}s L{int(remaining)}s",
+                font=font,
+                fill=255,
+            )
+        console.log(
             f"OLED display 중입니다... 남은 시간: {remaining}초 | "
-            f"CPU: {temp:.1f}°C | Fan: {fan_status}   ",
-
-            end="\r",
+            f"CPU: {temp:.1f}°C | CO2: {co2_ppm if co2_ppm is not None else 'N/A'}ppm | Fan: {fan_status}"
         )
         if remaining == 0:
             break
-
         time.sleep(5)
         remaining -= 5
-    console.print()
+    if co2_port:
+        co2_port.close()
 
 if __name__ == "__main__":
     main()

--- a/apps/oled_piroman5/requirements.txt
+++ b/apps/oled_piroman5/requirements.txt
@@ -1,4 +1,5 @@
 luma.oled
+luma.core
 Pillow
 gpiozero
-lume.core
+pyserial


### PR DESCRIPTION
## Summary
- allow ip_display.py to accept a `--fan-duty` percentage argument (default 100)
- show CO₂ sensor ppm on the OLED alongside network, time, CPU temp, and fan status
- document the CO₂ line and add pyserial to requirements while fixing luma.core entry
- display the current fan duty and remaining time in the two-minute cycle on the last line
- prevent dynamic console updates from erasing CO₂ sensor debug output by switching to line-based logging
- enumerate available USB serial ports and log the one used for the CO₂ sensor
- expose `cpu_fan_on` and `led_fan_on` helpers to manually activate the CPU fan and LED fan
- provide `fan_on.py` as a standalone utility to switch on the CPU fan and LED fan

## Testing
- `pip install luma.oled luma.core`
- `python apps/oled_piroman5/ip_display.py --help` *(ModuleNotFoundError: No module named 'berepi_logger')*
- `python -m py_compile apps/oled_piroman5/ip_display.py`
- `python -m py_compile apps/oled_piroman5/fan_on.py`


------
https://chatgpt.com/codex/tasks/task_e_68abb4166b1c8331bd7c40e5f448ccbf