### PR TITLE
feat: report and persist fan state

### DIFF
--- a/apps/oled_piroman5/fan_on.py
+++ b/apps/oled_piroman5/fan_on.py
@@ -4,43 +4,83 @@
 Running this script will turn on the fan connected to BCM pin 18 and
 light the two RGB LED outputs on pins 5 and 6. The state persists after
 exit so the fan and LEDs stay on.
+
+On startup it reports the current fan status, the level of GPIO 6 and the
+current CPU temperature using :mod:`rich` formatting.
 """
 
 import atexit
+import os
+import argparse
 
-from gpiozero import OutputDevice, Device
+from gpiozero import CPUTemperature, OutputDevice, Device
+from rich.console import Console
 
 FAN_PIN = 18
 RGBFAN_PIN = (5, 6)
 
 
-def cpu_fan_on(pin=FAN_PIN):
-    """Activate the CPU cooling fan and return its device."""
-    fan = OutputDevice(pin, active_high=True)
-    fan.on()
-    return fan
+def parse_args():
+    """Return parsed command line arguments."""
 
-
-def led_fan_on(pins=RGBFAN_PIN):
-    """Activate the LED fan outputs and return their devices."""
-    leds = [OutputDevice(pin, active_high=True) for pin in pins]
-    for led in leds:
-        led.on()
-    return leds
+    parser = argparse.ArgumentParser(
+        description="Control the CPU cooling fan and its RGB LEDs",
+    )
+    parser.add_argument(
+        "--state",
+        choices=["on", "off"],
+        default="on",
+        help="desired fan state",
+    )
+    return parser.parse_args()
 
 
 def main():
-    """Turn on the CPU fan and RGB LED fan."""
+    """Control the CPU fan and RGB LED fan."""
 
+    args = parse_args()
+    console = Console()
+
+    # Prevent gpiozero from resetting the pin states on exit so the fan
+    # remains running after this script terminates.
     if hasattr(Device, "_shutdown"):
         try:
             atexit.unregister(Device._shutdown)
         except Exception:
             pass
-    cpu_fan_on()
-    led_fan_on()
 
+    # Release any previously allocated pins to avoid GPIO busy errors.
+    for pin in (FAN_PIN,) + RGBFAN_PIN:
+        try:
+            Device.pin_factory.release(pin)
+        except Exception:
+            pass
+
+    # Inspect existing states without changing them
+    fan = OutputDevice(FAN_PIN, active_high=True, initial_value=None)
+    leds = [OutputDevice(pin, active_high=True, initial_value=None) for pin in RGBFAN_PIN]
+
+    cpu_temp = CPUTemperature().temperature
+    fan_state = "ON" if fan.is_active else "OFF"
+    gpio6_state = "HIGH" if leds[1].is_active else "LOW"
+
+    console.print(f"[bold]CPU fan:[/bold] {fan_state}")
+    console.print(f"[bold]GPIO 6:[/bold] {gpio6_state}")
+    console.print(f"[bold]CPU temp:[/bold] {cpu_temp:.1f}\N{DEGREE SIGN}C")
+    console.print(f"[bold]Requested state:[/bold] {args.state.upper()}")
+
+    # Apply requested state
+    if args.state == "on":
+        fan.on()
+        for led in leds:
+            led.on()
+    else:
+        fan.off()
+        for led in leds:
+            led.off()
 
 
 if __name__ == "__main__":
     main()
+    # Exit immediately to avoid any library clean-up resetting the pins
+    os._exit(0)


### PR DESCRIPTION
## Summary
- add argparse-based `--state` flag to control whether fan and RGB LEDs turn on or off
- display requested state along with current fan, GPIO 6 level and CPU temperature
- release pins and suppress gpiozero cleanup so fan/LED state persists after exit

## Testing
- `python -m py_compile apps/oled_piroman5/fan_on.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae40c5e4888331a7cfbbcb6c76b18b