### PR TITLE
doc: explain running gpioset without root

### DIFF
--- a/apps/booted/pironman5.sh
+++ b/apps/booted/pironman5.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
+# NOTE: `gpioset`/`gpioget` generally need root privileges to access
+# `/dev/gpiochip*`. To run this script as a normal user, grant access via
+# a `gpio` group or capabilities. For example:
+#   sudo usermod -aG gpio "$USER"
+#   echo 'SUBSYSTEM=="gpio",KERNEL=="gpiochip*",GROUP="gpio",MODE="0660"' | \
+#       sudo tee /etc/udev/rules.d/60-gpio.rules
+#   sudo udevadm control --reload-rules && sudo udevadm trigger
+# or
+#   sudo setcap 'cap_sys_rawio+ep' $(command -v gpioset) $(command -v gpioget)
+
 #CASE FAN (LED FAN)
-#output GPIO6 = 1  
+#output GPIO6 = 1
 echo -n "chang output, current="
 gpioget gpiochip4 6
 
-gpioset gpiochip4 6=1 
+gpioset gpiochip4 6=1
 
 echo -n " pin status GPIO6 >> " 
 gpioget gpiochip4 6


### PR DESCRIPTION
## Summary
- document how to configure gpioset/gpioget for non-root use in boot script

## Testing
- `bash -n apps/booted/pironman5.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b442500d5c8331b25ffe63706183af