### PR TITLE
Remove duplicate numpy import in PDF RAG app

### DIFF
--- a/apps/openai_pdf_rag/app.py
+++ b/apps/openai_pdf_rag/app.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 from fpdf import FPDF
 
-import numpy as np
 import streamlit as st
 from openai import OpenAI
 from PyPDF2 import PdfReader


### PR DESCRIPTION
## Summary
- Deduplicate numpy import in `apps/openai_pdf_rag/app.py` to avoid redundant statements.

## Testing
- `python -m py_compile apps/openai_pdf_rag/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68bbce3dc2dc8331986c62bc0484f0f2