### PR TITLE
feat: add model selectbox for PDF RAG apps

### DIFF
--- a/apps/openai_pdf_rag/README.md
+++ b/apps/openai_pdf_rag/README.md
@@ -11,15 +11,19 @@
    pip install streamlit openai PyPDF2 numpy pandas fpdf
    ```
    OpenAI API 키는 `OPENAI_API_KEY` 환경 변수 또는 `nocommit.txt` 파일을 통해
-   설정할 수 있습니다.
+   설정할 수 있습니다. Gemma 등 허깅페이스에서 접근 제한이 있는 모델을
+   사용하려면 `HF_TOKEN` 환경 변수나 `hf_token.txt` 파일에 Hugging Face 토큰을
+   제공해야 합니다.
 
 2. 앱 실행
    ```bash
    streamlit run app.py
    ```
 
-앱 상단에는 시스템에 설치된 GPU와 사용 중인 AI 모델(gpt-3.5-turbo)이 표시됩니다.
-또한 질문 입력란 위에 가로줄을 넣어 영역을 구분합니다.
+앱 상단에는 시스템에 설치된 GPU(개수 및 모델)와 선택한 AI 모델이 표시됩니다.
+또한 질문 입력란 위에 가로줄을 넣어 영역을 구분합니다. OpenAI 모델 외에도
+llama-3, mistral, gemma 등 OSS 모델을 선택할 수 있으며, 로컬에 모델이 없으면
+다운로드 버튼이 나타나고 다운로드 후 파일 무결성을 검사합니다.
 
 질문을 입력하면 첫 번째 영역에 기본 답변이 표시됩니다.
 

--- a/apps/openai_pdf_rag/app.py
+++ b/apps/openai_pdf_rag/app.py
@@ -6,10 +6,110 @@ import numpy as np
 import pandas as pd
 from fpdf import FPDF
 
-import numpy as np
 import streamlit as st
-from openai import OpenAI
+from openai import BadRequestError, OpenAI
 from PyPDF2 import PdfReader
+
+
+MODEL_OPTIONS = {
+    "gpt-3.5-turbo": "gpt-3.5-turbo",
+    "gpt-4o-mini": "gpt-4o-mini",
+    "llama-3": "meta-llama/Meta-Llama-3-8B-Instruct",
+    "mistral": "mistralai/Mistral-7B-Instruct-v0.2",
+    "gemma": "google/gemma-2b-it",
+}
+
+
+def load_hf_token() -> str | None:
+    token = os.getenv("HF_TOKEN")
+    if token:
+        return token.strip()
+    token_paths = [
+        os.path.join(os.path.dirname(__file__), "hf_token.txt"),
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "hf_token.txt"),
+    ]
+    for path in token_paths:
+        if os.path.isfile(path):
+            with open(path, "r", encoding="utf-8") as f:
+                return f.read().strip()
+    return None
+
+
+def _verify_model_files(path: str) -> bool:
+    config = os.path.join(path, "config.json")
+    if not os.path.isfile(config) or os.path.getsize(config) <= 0:
+        return False
+    weight_files = [
+        f
+        for f in os.listdir(path)
+        if f.endswith((".bin", ".safetensors"))
+    ]
+    if not weight_files:
+        return False
+    for wf in weight_files:
+        if os.path.getsize(os.path.join(path, wf)) <= 0:
+            return False
+    return True
+
+
+def ensure_model(repo_id: str) -> None:
+    """Ensure that an OSS model is downloaded and valid before use."""
+    if os.path.isdir(repo_id) and _verify_model_files(repo_id):
+        return
+    try:
+        from huggingface_hub import hf_hub_download, snapshot_download, login
+        from huggingface_hub.utils import GatedRepoError
+    except Exception:
+        st.error("huggingface_hub 라이브러리가 필요합니다.")
+        st.stop()
+
+    token = load_hf_token()
+    if token:
+        try:
+            login(token=token)
+        except Exception:
+            st.error("Hugging Face 로그인 실패")
+            st.stop()
+
+    def _download() -> None:
+        with st.spinner("모델 다운로드 중..."):
+            try:
+                snapshot_download(
+                    repo_id=repo_id,
+                    local_dir=repo_id,
+                    force_download=True,
+                    token=token,
+                )
+            except GatedRepoError:
+                st.error(
+                    "허깅페이스 토큰이 필요합니다. HF_TOKEN 환경변수 또는 hf_token.txt 파일을 설정하세요."
+                )
+                st.stop()
+        if _verify_model_files(repo_id):
+            st.success("다운로드 완료")
+        else:
+            st.error("모델 파일 검증 실패")
+            st.stop()
+
+    try:
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            local_files_only=True,
+            token=token,
+        )
+        if not _verify_model_files(repo_id):
+            _download()
+    except GatedRepoError:
+        st.error(
+            "허깅페이스 토큰이 필요합니다. HF_TOKEN 환경변수 또는 hf_token.txt 파일을 설정하세요."
+        )
+        st.stop()
+    except Exception:
+        if st.button(f"{repo_id} 다운로드"):
+            _download()
+        else:
+            st.stop()
 
 
 def get_gpu_info() -> str:
@@ -18,9 +118,8 @@ def get_gpu_info() -> str:
             ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
             stderr=subprocess.DEVNULL,
         )
-        gpus = out.decode().strip().split("\n")
-        gpus = [g for g in gpus if g]
-        return ", ".join(gpus) if gpus else "GPU 없음"
+        gpus = [g for g in out.decode().strip().split("\n") if g]
+        return f"{len(gpus)}개 ({', '.join(gpus)})" if gpus else "GPU 없음"
     except Exception:
         return "GPU 없음"
       
@@ -44,7 +143,26 @@ client = OpenAI(api_key=OPENAI_API_KEY)
 st.set_page_config(page_title="PDF RAG Chat")
 st.title("📄 PDF 기반 Q&A")
 st.write(f"사용 가능한 GPU: {get_gpu_info()}")
-st.write("사용 모델: gpt-3.5-turbo")
+model_name = st.selectbox("모델 선택", list(MODEL_OPTIONS.keys()))
+model = MODEL_OPTIONS[model_name]
+if model_name in ["llama-3", "mistral", "gemma"]:
+    ensure_model(model)
+st.write(f"사용 모델: {model_name}")
+
+if "errors" not in st.session_state:
+    st.session_state.errors = []
+
+
+def log_error(msg: str) -> None:
+    st.session_state.errors.append(msg)
+    st.session_state.errors = st.session_state.errors[-3:]
+
+
+def reset_app() -> None:
+    for key in list(st.session_state.keys()):
+        if key != "errors":
+            del st.session_state[key]
+    st.rerun()
 
 if "docs" not in st.session_state:
     st.session_state.docs = None
@@ -125,10 +243,14 @@ if question:
         st.subheader("1. 기본 답변")
         with st.spinner("답변 생성 중..."):
             start_t = time.perf_counter()
-            resp = client.chat.completions.create(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "user", "content": question}],
-            )
+            try:
+                resp = client.chat.completions.create(
+                    model=model,
+                    messages=[{"role": "user", "content": question}],
+                )
+            except BadRequestError as e:
+                log_error(str(e))
+                reset_app()
             elapsed_default = time.perf_counter() - start_t
             default_answer = resp.choices[0].message.content
             st.write(default_answer)
@@ -164,11 +286,14 @@ if question:
                         + question
                     )
                     start_pdf = time.perf_counter()
-
-                    resp = client.chat.completions.create(
-                        model="gpt-3.5-turbo",
-                        messages=[{"role": "user", "content": prompt}],
-                    )
+                    try:
+                        resp = client.chat.completions.create(
+                            model=model,
+                            messages=[{"role": "user", "content": prompt}],
+                        )
+                    except BadRequestError as e:
+                        log_error(str(e))
+                        reset_app()
                     elapsed_pdf = time.perf_counter() - start_pdf
                     pdf_answer = resp.choices[0].message.content
                     st.write(pdf_answer)
@@ -226,4 +351,8 @@ if st.session_state.history:
                 mime="application/pdf",
             )
 
-
+if st.session_state.errors:
+    st.markdown("---")
+    st.subheader("에러 메시지")
+    for err in st.session_state.errors[-3:]:
+        st.error(err)

--- a/apps/openai_pdf_rag/streamlit_multi_pdf_rag.py
+++ b/apps/openai_pdf_rag/streamlit_multi_pdf_rag.py
@@ -1,12 +1,120 @@
 
 import os
+import subprocess
 from typing import List
 
 import numpy as np
 import streamlit as st
-from openai import OpenAI
+from openai import BadRequestError, OpenAI
 from PyPDF2 import PdfReader
 
+
+MODEL_OPTIONS = {
+    "gpt-3.5-turbo": "gpt-3.5-turbo",
+    "gpt-4o-mini": "gpt-4o-mini",
+    "llama-3": "meta-llama/Meta-Llama-3-8B-Instruct",
+    "mistral": "mistralai/Mistral-7B-Instruct-v0.2",
+    "gemma": "google/gemma-2b-it",
+}
+
+
+def load_hf_token() -> str | None:
+    token = os.getenv("HF_TOKEN")
+    if token:
+        return token.strip()
+    token_paths = [
+        os.path.join(os.path.dirname(__file__), "hf_token.txt"),
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "hf_token.txt"),
+    ]
+    for path in token_paths:
+        if os.path.isfile(path):
+            with open(path, "r", encoding="utf-8") as f:
+                return f.read().strip()
+    return None
+
+
+def _verify_model_files(path: str) -> bool:
+    config = os.path.join(path, "config.json")
+    if not os.path.isfile(config) or os.path.getsize(config) <= 0:
+        return False
+    weights = [f for f in os.listdir(path) if f.endswith((".bin", ".safetensors"))]
+    if not weights:
+        return False
+    for wf in weights:
+        if os.path.getsize(os.path.join(path, wf)) <= 0:
+            return False
+    return True
+
+
+def ensure_model(repo_id: str) -> None:
+    if os.path.isdir(repo_id) and _verify_model_files(repo_id):
+        return
+    try:
+        from huggingface_hub import hf_hub_download, snapshot_download, login
+        from huggingface_hub.utils import GatedRepoError
+    except Exception:
+        st.error("huggingface_hub 라이브러리가 필요합니다.")
+        st.stop()
+
+    token = load_hf_token()
+    if token:
+        try:
+            login(token=token)
+        except Exception:
+            st.error("Hugging Face 로그인 실패")
+            st.stop()
+
+    def _download() -> None:
+        with st.spinner("모델 다운로드 중..."):
+            try:
+                snapshot_download(
+                    repo_id=repo_id,
+                    local_dir=repo_id,
+                    force_download=True,
+                    token=token,
+                )
+            except GatedRepoError:
+                st.error(
+                    "허깅페이스 토큰이 필요합니다. HF_TOKEN 환경변수 또는 hf_token.txt 파일을 설정하세요."
+                )
+                st.stop()
+        if _verify_model_files(repo_id):
+            st.success("다운로드 완료")
+        else:
+            st.error("모델 파일 검증 실패")
+            st.stop()
+
+    try:
+        hf_hub_download(
+            repo_id=repo_id,
+            filename="config.json",
+            local_files_only=True,
+            token=token,
+        )
+        if not _verify_model_files(repo_id):
+            _download()
+    except GatedRepoError:
+        st.error(
+            "허깅페이스 토큰이 필요합니다. HF_TOKEN 환경변수 또는 hf_token.txt 파일을 설정하세요."
+        )
+        st.stop()
+    except Exception:
+        if st.button(f"{repo_id} 다운로드"):
+            _download()
+        else:
+            st.stop()
+
+
+def get_gpu_info() -> str:
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            stderr=subprocess.DEVNULL,
+        )
+        gpus = [g for g in out.decode().strip().split("\n") if g]
+        return f"{len(gpus)}개 ({', '.join(gpus)})" if gpus else "GPU 없음"
+    except Exception:
+        return "GPU 없음"
 
 def load_api_key() -> str | None:
     """Read the OpenAI API key from a nocommit.txt file."""
@@ -30,9 +138,28 @@ client = OpenAI(api_key=api_key)
 
 st.set_page_config(page_title="PDF RAG Chat")
 st.title("📄 PDF RAG Chat")
+st.write(f"사용 가능한 GPU: {get_gpu_info()}")
 
-model = st.text_input("사용할 GPT 모델", "gpt-4o-mini")
-st.caption(f"사용 모델: {model}")
+model_name = st.selectbox("모델 선택", list(MODEL_OPTIONS.keys()))
+model = MODEL_OPTIONS[model_name]
+if model_name in ["llama-3", "mistral", "gemma"]:
+    ensure_model(model)
+st.caption(f"사용 모델: {model_name}")
+
+if "errors" not in st.session_state:
+    st.session_state.errors = []
+
+
+def log_error(msg: str) -> None:
+    st.session_state.errors.append(msg)
+    st.session_state.errors = st.session_state.errors[-3:]
+
+
+def reset_app() -> None:
+    for key in list(st.session_state.keys()):
+        if key != "errors":
+            del st.session_state[key]
+    st.rerun()
 
 
 uploaded_files = st.file_uploader(
@@ -108,7 +235,11 @@ if question:
             + question
         )
         with st.spinner("RAG 답변 생성 중..."):
-            completion = client.responses.create(model=model, input=prompt)
+            try:
+                completion = client.responses.create(model=model, input=prompt)
+            except BadRequestError as e:
+                log_error(str(e))
+                reset_app()
         rag_answer = completion.output_text
 
         st.text_area("RAG 답변", rag_answer, height=200)
@@ -116,8 +247,18 @@ if question:
         st.warning("먼저 PDF 파일을 업로드하세요.")
 
     with st.spinner("일반 답변 생성 중..."):
-        direct_completion = client.responses.create(model=model, input=question)
+        try:
+            direct_completion = client.responses.create(model=model, input=question)
+        except BadRequestError as e:
+            log_error(str(e))
+            reset_app()
     direct_answer = direct_completion.output_text
 
     st.text_area("일반 모델 답변", direct_answer, height=200)
+
+if st.session_state.errors:
+    st.markdown("---")
+    st.subheader("에러 메시지")
+    for err in st.session_state.errors[-3:]:
+        st.error(err)
 


### PR DESCRIPTION
## Summary
- add dropdown for choosing OpenAI or OSS models in PDF RAG demos
- ensure local availability of OSS models with optional download and file integrity checks
- wire chat and response calls to selected model and display GPU count and model name
- reset app and log recent errors when the selected model is unavailable
- authenticate Hugging Face downloads for gated OSS models via `HF_TOKEN`
- replace deprecated `resume_download` with `force_download` for reliable Hugging Face downloads

## Testing
- `python -m py_compile apps/openai_pdf_rag/app.py apps/openai_pdf_rag/streamlit_multi_pdf_rag.py && echo DONE`


------
https://chatgpt.com/codex/tasks/task_e_68bbce2edf988331921741cc90ff3914