### PR TITLE
Fix OpenAI query calls in PDF RAG app

### DIFF
--- a/apps/openai_pdf_rag/app.py
+++ b/apps/openai_pdf_rag/app.py
@@ -367,16 +367,16 @@ if question:
         with st.spinner("답변 생성 중..."):
             start_t = time.perf_counter()
             try:
-                resp = client.chat.completions.create(
+                resp = client.responses.create(
                     model=model,
-                    messages=[{"role": "user", "content": question}],
+                    input=question,
                 )
             except BadRequestError as e:
                 log_error(str(e))
                 reset_app()
 
             elapsed_default = time.perf_counter() - start_t
-            default_answer = resp.choices[0].message.content
+            default_answer = resp.output_text
             st.write(default_answer)
             st.write(f"⏱️ {elapsed_default:.2f}초")
 
@@ -411,16 +411,16 @@ if question:
                     )
                     start_pdf = time.perf_counter()
                     try:
-                        resp = client.chat.completions.create(
+                        resp = client.responses.create(
                             model=model,
-                            messages=[{"role": "user", "content": prompt}],
+                            input=prompt,
                         )
                     except BadRequestError as e:
                         log_error(str(e))
                         reset_app()
 
                     elapsed_pdf = time.perf_counter() - start_pdf
-                    pdf_answer = resp.choices[0].message.content
+                    pdf_answer = resp.output_text
                     st.write(pdf_answer)
                     st.write(f"⏱️ {elapsed_pdf:.2f}초")
 


### PR DESCRIPTION
## Summary
- switch PDF RAG app to OpenAI `responses` API for both regular and PDF-based answers
- keep embeddings workflow and error handling

## Testing
- `python -m py_compile apps/openai_pdf_rag/app.py apps/openai_pdf_rag/streamlit_multi_pdf_rag.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd09c4b7408331ac92a372063cd7c6