### PR TITLE
feat: expand pandasai streamlit modes

### DIFF
--- a/apps/singlestore/minio_pandasai_stats.py
+++ b/apps/singlestore/minio_pandasai_stats.py
@@ -2,9 +2,15 @@
 
 This script downloads a CSV file from a MinIO bucket into a Pandas
 ``DataFrame`` and exposes it via a small web application powered by
-`streamlit`. The app shows basic statistics and lets the user provide an
-arbitrary natural-language prompt for `pandas-ai` to answer.  It demonstrates
-how to compute statistics such as:
+`streamlit`.  Users can ask questions about the data in plain language and the
+app will employ :class:`~pandasai.SmartDataframe` to answer.  Besides natural
+language replies, the interface can request SQL queries or generic statistics
+descriptions, showcasing a few different capabilities of ``SmartDataframe``.
+Several ready-made analytics helpers are also provided, including seasonal and
+vehicle-type aggregations, per-trip distance summaries, simple state-of-charge
+usage over time, and speed-versus-power breakdowns.
+
+It demonstrates how to compute statistics such as:
 
 * number of unique ``dev_id`` values
 * per ``dev_id`` row counts
@@ -22,10 +28,18 @@ The script requires the following environment variables:
 ``OPENAI_API_KEY``      – API token used by pandas-ai for LLM access
 ``OPENAI_MODEL``        – Optional OpenAI model name (defaults to
                           ``gpt-3.5-turbo``)
+``VEHICLE_FIELD``       – Column containing vehicle type (optional)
+``DIST_FIELD``          – Column containing travelled distance (optional)
+``DURATION_FIELD``      – Column containing trip duration (optional)
+``SOC_FIELD``           – Column with state-of-charge values (optional)
+``SPEED_FIELD``         – Column with speed readings (optional)
+``POWER_FIELD``         – Column with power or energy usage (optional)
 
 Running ``streamlit run minio_pandasai_stats.py`` will start a web interface
 that displays the statistics table and, when the user submits a prompt, shows
-the LLM's reply along with the active GPU and model information.
+the LLM's reply along with the active GPU and model information.  Depending on
+the selected mode, the reply may be plain text, a SQL statement, or a summary
+of computed statistics.
 """
 
 from __future__ import annotations
@@ -35,6 +49,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 from minio import Minio
 
@@ -86,17 +101,144 @@ def compute_stats(df: pd.DataFrame, id_field: str, time_field: str) -> pd.DataFr
     return grouped
 
 
-def analyze_with_pandasai(df: pd.DataFrame, prompt: str, model_name: str):
-    """Ask an LLM for a natural language summary using pandas-ai.
+def seasonal_analysis(
+    df: pd.DataFrame, time_field: str, distance_field: str | None, soc_field: str | None
+) -> pd.DataFrame:
+    """Return average metrics grouped by season.
 
-    The return value may be plain text, a path to a generated chart image,
-    or other objects produced by the underlying LLM.
+    Months are mapped to seasons (winter, spring, summer, autumn) and the
+    returned frame contains the mean of numeric columns.  Optional ``distance``
+    and ``soc`` fields are highlighted if present.
     """
+
+    if time_field not in df.columns:
+        raise ValueError("time field not found")
+
+    season_map = {
+        12: "winter",
+        1: "winter",
+        2: "winter",
+        3: "spring",
+        4: "spring",
+        5: "spring",
+        6: "summer",
+        7: "summer",
+        8: "summer",
+        9: "autumn",
+        10: "autumn",
+        11: "autumn",
+    }
+
+    tmp = df.copy()
+    tmp["season"] = tmp[time_field].dt.month.map(season_map)
+    agg_cols: dict[str, str] = {}
+    if distance_field and distance_field in tmp.columns:
+        agg_cols[distance_field] = "mean"
+    if soc_field and soc_field in tmp.columns:
+        agg_cols[soc_field] = "mean"
+    if not agg_cols:
+        agg_cols = {c: "mean" for c in tmp.select_dtypes("number").columns}
+    return tmp.groupby("season").agg(agg_cols)
+
+
+def vehicle_type_analysis(
+    df: pd.DataFrame, vehicle_field: str, distance_field: str | None, soc_field: str | None
+) -> pd.DataFrame:
+    """Return average metrics grouped by vehicle type."""
+
+    if vehicle_field not in df.columns:
+        raise ValueError("vehicle type field not found")
+
+    agg_cols: dict[str, str] = {}
+    if distance_field and distance_field in df.columns:
+        agg_cols[distance_field] = "mean"
+    if soc_field and soc_field in df.columns:
+        agg_cols[soc_field] = "mean"
+    if not agg_cols:
+        agg_cols = {c: "mean" for c in df.select_dtypes("number").columns}
+    return df.groupby(vehicle_field).agg(agg_cols)
+
+
+def trip_distance_analysis(
+    df: pd.DataFrame, distance_field: str, duration_field: str | None
+) -> pd.DataFrame:
+    """Summarize distance and optional duration per trip."""
+
+    if distance_field not in df.columns:
+        raise ValueError("distance field not found")
+
+    data = {"distance": df[distance_field].describe()}
+    if duration_field and duration_field in df.columns:
+        data["duration"] = df[duration_field].describe()
+    return pd.DataFrame(data)
+
+
+def soc_usage_over_time(
+    df: pd.DataFrame, time_field: str, distance_field: str, soc_field: str
+) -> pd.DataFrame:
+    """Return SOC decrease per distance over time."""
+
+    for col in (time_field, distance_field, soc_field):
+        if col not in df.columns:
+            raise ValueError(f"{col} field not found")
+
+    ordered = df.sort_values(time_field).reset_index(drop=True)
+    start_dist = ordered.loc[0, distance_field]
+    start_soc = ordered.loc[0, soc_field]
+    ordered["dist_delta"] = ordered[distance_field] - start_dist
+    ordered["soc_delta"] = start_soc - ordered[soc_field]
+    ordered["soc_per_distance"] = ordered["soc_delta"] / ordered["dist_delta"].replace(0, np.nan)
+    return ordered[[time_field, distance_field, soc_field, "soc_per_distance"]]
+
+
+def speed_power_analysis(
+    df: pd.DataFrame, speed_field: str, power_field: str
+) -> pd.DataFrame:
+    """Return mean power grouped by speed ranges."""
+
+    for col in (speed_field, power_field):
+        if col not in df.columns:
+            raise ValueError(f"{col} field not found")
+
+    bins = [0, 20, 40, 60, 80, 100, 120, np.inf]
+    labels = ["0-20", "20-40", "40-60", "60-80", "80-100", "100-120", "120+"]
+    tmp = df.copy()
+    tmp["speed_bin"] = pd.cut(tmp[speed_field], bins=bins, labels=labels, right=False)
+    return tmp.groupby("speed_bin")[power_field].mean().to_frame(name="mean_power")
+
+
+def analyze_with_pandasai(
+    df: pd.DataFrame, prompt: str, model_name: str, mode: str
+):
+    """Run a ``SmartDataframe`` interaction according to ``mode``.
+
+    ``mode`` selects which capability of ``SmartDataframe`` should be used.
+    Currently supported options are:
+
+    * ``"Natural language"`` – basic :py:meth:`SmartDataframe.chat` usage
+    * ``"Generate SQL"`` – ask the LLM to create a SQL query
+    * ``"Data statistics"`` – request statistical summaries
+
+    The return value is a tuple ``(result, code)`` where ``code`` contains the
+    Python snippet produced by pandas-ai (if available).
+    """
+
     if SmartDataframe is None or OpenAI is None:
         raise RuntimeError("pandas-ai is not installed")
+
     llm = OpenAI(api_token=os.environ["OPENAI_API_KEY"], model_name=model_name)
     sdf = SmartDataframe(df, config={"llm": llm, "save_charts": True})
-    return sdf.chat(prompt)
+
+    if mode == "Generate SQL":
+        # Encourage the LLM to emit only a SQL statement
+        prompt = f"Generate a SQL query for the following request and return only the SQL statement:\n{prompt}"
+    elif mode == "Data statistics":
+        # Preface the request so pandas-ai focuses on statistics
+        prompt = f"Using dataframe statistics, {prompt}"
+
+    result = sdf.chat(prompt)
+    code = getattr(sdf, "last_code_executed", None)
+    return result, code
 
 
 def gpu_info() -> str:
@@ -118,6 +260,12 @@ def main() -> None:  # pragma: no cover - entry point for streamlit
     id_field = os.environ.get("ID_FIELD", "dev_id")
     time_field = os.environ.get("TIME_FIELD", "coll_dt")
     model_name = os.environ.get("OPENAI_MODEL", "gpt-3.5-turbo")
+    vehicle_field = os.environ.get("VEHICLE_FIELD", "vehicle_type")
+    distance_field = os.environ.get("DIST_FIELD", "distance")
+    duration_field = os.environ.get("DURATION_FIELD", "duration")
+    soc_field = os.environ.get("SOC_FIELD", "soc")
+    speed_field = os.environ.get("SPEED_FIELD", "speed")
+    power_field = os.environ.get("POWER_FIELD", "power")
     cfg = MinioConfig(
         endpoint=os.environ["MINIO_ENDPOINT"],
         access_key=os.environ["MINIO_ACCESS_KEY"],
@@ -137,25 +285,69 @@ def main() -> None:  # pragma: no cover - entry point for streamlit
     st.write(f"Unique {id_field} count: {len(stats)}")
     st.dataframe(stats)
 
+    st.subheader("Preset analyses")
+    analysis = st.selectbox(
+        "Analysis type",
+        [
+            "None",
+            "Seasonal",
+            "Vehicle type",
+            "Trip distance/time",
+            "SOC vs distance over time",
+            "Speed vs power deceleration",
+        ],
+    )
+
+    if analysis != "None":
+        try:
+            if analysis == "Seasonal":
+                result = seasonal_analysis(df, time_field, distance_field, soc_field)
+            elif analysis == "Vehicle type":
+                result = vehicle_type_analysis(df, vehicle_field, distance_field, soc_field)
+            elif analysis == "Trip distance/time":
+                result = trip_distance_analysis(df, distance_field, duration_field)
+            elif analysis == "SOC vs distance over time":
+                result = soc_usage_over_time(df, time_field, distance_field, soc_field)
+            elif analysis == "Speed vs power deceleration":
+                result = speed_power_analysis(df, speed_field, power_field)
+            st.dataframe(result)
+        except Exception as exc:  # pragma: no cover - runtime failures
+            st.warning(f"Analysis unavailable: {exc}")
+
     default_prompt = (
         f"Count the unique values in '{id_field}'. For each '{id_field}', give the row count, "
         f"earliest '{time_field}', latest '{time_field}', and total memory usage in bytes. "
         "Return the answer as a table with columns id, rows, oldest, newest, bytes."
     )
-    user_prompt = st.text_area("LLM Prompt", value=default_prompt)
+
+    user_prompt = st.text_area(
+        "Prompt", value=default_prompt, help="Describe a task in natural language"
+    )
+    mode = st.selectbox(
+        "Response type",
+        ["Natural language", "Generate SQL", "Data statistics"],
+    )
 
     if st.button("Run LLM"):
         try:
-            reply = analyze_with_pandasai(df, user_prompt, model_name)
+            reply, code = analyze_with_pandasai(df, user_prompt, model_name, mode)
             st.subheader("LLM Reply")
-            # If pandas-ai returns a path to a chart, render it; otherwise show text
-            if isinstance(reply, str) and Path(reply).exists():
-                if reply.lower().endswith(".html"):
-                    st.components.v1.html(Path(reply).read_text(), height=400)
-                else:
-                    st.image(reply)
+
+            if mode == "Generate SQL":
+                st.code(str(reply), language="sql")
             else:
-                st.write(reply)
+                # If pandas-ai returns a path to a chart, render it; otherwise show text
+                if isinstance(reply, str) and Path(reply).exists():
+                    if reply.lower().endswith(".html"):
+                        st.components.v1.html(Path(reply).read_text(), height=400)
+                    else:
+                        st.image(reply)
+                else:
+                    st.write(reply)
+
+            if code:
+                st.subheader("Generated code")
+                st.code(code, language="python")
         except Exception as exc:  # pragma: no cover - runtime failures
             st.error(f"pandas-ai analysis skipped: {exc}")
 


### PR DESCRIPTION
## Summary
- document new optional fields and built-in analytics helpers
- add seasonal, vehicle-type, trip, SOC decay, and speed-power analysis utilities
- expose preset analysis selector within the Streamlit MinIO stats app

## Testing
- `pytest` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a463fe4883318699fe6272dff1db