### PR TITLE
Parse MinIO defaults from config for UI and CLI

### DIFF
--- a/apps/minio/scan/main.py
+++ b/apps/minio/scan/main.py
@@ -81,6 +81,22 @@ def _normalize_path(value: Any) -> Optional[str]:
     return None
 
 
+def _normalize_bucket(value: Any) -> str:
+    """Return a sanitized bucket value or an empty string."""
+
+    if isinstance(value, str):
+        return value.strip()
+    return ""
+
+
+def _normalize_prefix(value: Any) -> str:
+    """Return a sanitized prefix value or an empty string."""
+
+    if isinstance(value, str):
+        return value.strip()
+    return ""
+
+
 def resolve_ssl_options(
     config: dict,
 ) -> Tuple[bool, Dict[str, Any], Optional[urllib3.PoolManager], bool]:
@@ -315,9 +331,10 @@ def load_config(*, show_feedback: bool = True) -> dict:
     The configuration file is stored alongside this module in
     ``apps/minio/scan`` and should contain ``endpoint``, ``access_key`` and
     ``secret_key`` keys. ``secure`` toggles HTTPS and defaults to ``False``.
-    For deployments that require custom TLS certificates, add an ``ssl``
-    section with ``enabled``, ``cert_check``, ``ca_file``, ``cert_file`` and
-    ``key_file`` entries.
+    ``bucket`` and ``prefix`` provide optional defaults that are applied to the
+    CLI commands and Streamlit UI. For deployments that require custom TLS
+    certificates, add an ``ssl`` section with ``enabled``, ``cert_check``,
+    ``ca_file``, ``cert_file`` and ``key_file`` entries.
     """
 
     cfg_path = Path(__file__).resolve().parent / "nocommit_minio.json"
@@ -327,6 +344,8 @@ def load_config(*, show_feedback: bool = True) -> dict:
         "access_key": "your-access-key",
         "secret_key": "your-secret-key",
         "secure": False,
+        "bucket": "your-bucket-name",
+        "prefix": "optional/path/prefix/",
         "ssl": {
             "enabled": False,
             "cert_check": True,
@@ -363,13 +382,18 @@ def load_config(*, show_feedback: bool = True) -> dict:
 
     try:
         with open(cfg_path, encoding="utf-8") as f:
-            return json.load(f)
+            config = json.load(f)
     except json.JSONDecodeError as exc:
         error_msg = f"Invalid JSON in {cfg_path}: {exc}"
         print(error_msg)
         if show_feedback:
             st.error(error_msg)
         return {}
+
+    config["bucket"] = _normalize_bucket(config.get("bucket"))
+    config["prefix"] = _normalize_prefix(config.get("prefix"))
+
+    return config
 
 
 def run_streamlit_app() -> None:
@@ -387,14 +411,24 @@ def run_streamlit_app() -> None:
     if not config:
         return
 
+    bucket_default = config.get("bucket", "") or ""
+    prefix_default = config.get("prefix", "") or ""
 
     secure, ssl_config, http_client, cert_check = resolve_ssl_options(config)
+    scheme = "https" if secure else "http"
     conn_msg = (
-        f"Connecting to MinIO at {config['endpoint']} as {config['access_key']} "
-        f"(secure={secure}, cert_check={cert_check})"
+        f"Connecting to MinIO at {config['endpoint']} via {scheme.upper()} "
+        f"as {config['access_key']} (secure={secure}, cert_check={cert_check})"
     )
     st.write(conn_msg)
     print(conn_msg)
+    config_summary = (
+        "Configured defaults -> secure="
+        f"{secure} ({scheme}), bucket={bucket_default or '(not set)'}, "
+        f"prefix={prefix_default or '(not set)'}"
+    )
+    st.info(config_summary)
+    print(config_summary)
     if config.get("ssl") is not None:
         ssl_display = format_ssl_display(ssl_config)
         st.write("SSL options:")
@@ -415,8 +449,10 @@ def run_streamlit_app() -> None:
     )
 
     with fields_tab:
-        bucket1 = st.text_input("Bucket", key="bucket1")
-        prefix1 = st.text_input("Path prefix", key="prefix1")
+        bucket1 = st.text_input("Bucket", value=bucket_default, key="bucket1")
+        prefix1 = st.text_input(
+            "Path prefix", value=prefix_default, key="prefix1"
+        )
         if st.button("Scan", key="scan_btn") and bucket1:
             progress = st.progress(0)
             status = st.empty()
@@ -426,8 +462,10 @@ def run_streamlit_app() -> None:
                 st.write(", ".join(fields))
 
     with stats_tab:
-        bucket2 = st.text_input("Bucket", key="bucket2")
-        prefix2 = st.text_input("Path prefix", key="prefix2")
+        bucket2 = st.text_input("Bucket", value=bucket_default, key="bucket2")
+        prefix2 = st.text_input(
+            "Path prefix", value=prefix_default, key="prefix2"
+        )
         field_name = st.text_input("Field name")
         if st.button("Analyze", key="analyze_btn") and bucket2 and field_name:
             progress = st.progress(0)
@@ -441,11 +479,15 @@ def run_streamlit_app() -> None:
                 st.write(f"Missing ratio: {missing / total:.2%}")
 
     with modify_tab:
-        bucket3 = st.text_input("Source bucket", key="bucket3")
+        bucket3 = st.text_input(
+            "Source bucket", value=bucket_default, key="bucket3"
+        )
         object_path = st.text_input("CSV object path", key="object_path")
         field_to_remove = st.text_input("Field to remove", key="field_to_remove")
         dest_bucket = st.text_input(
-            "Destination bucket (optional)", key="dest_bucket"
+            "Destination bucket (optional)",
+            value=bucket_default,
+            key="dest_bucket",
         )
         dest_object = st.text_input("Destination object name", key="dest_object")
         if st.button("Copy CSV without field", key="copy_btn"):
@@ -486,54 +528,30 @@ def run_streamlit_app() -> None:
 def run_cli() -> None:
     """Provide a CLI alternative to the Streamlit interface."""
 
+    prog_name = Path(__file__).name
     parser = argparse.ArgumentParser(
+        prog=prog_name,
         description=(
             "MinIO CSV utilities. Use `streamlit run main.py` for the web UI or the"
             " commands below for terminal usage."
-        )
+        ),
     )
-    subparsers = parser.add_subparsers(dest="command")
-
-    list_parser = subparsers.add_parser(
-        "list",
-        help="List CSV files and show their fields",
-    )
-    list_parser.add_argument("bucket", help="Bucket name")
-    list_parser.add_argument(
-        "prefix",
+    parser.add_argument(
+        "command",
         nargs="?",
-        default="",
-        help="Prefix path to scan (defaults to entire bucket)",
+        choices=["list", "stats", "copy"],
+        help="Command to execute",
     )
+    parser.add_argument(
+        "command_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments for the selected command",
+    )
+    parsed = parser.parse_args()
 
-    stats_parser = subparsers.add_parser(
-        "stats",
-        help="Show total rows and missing values for a field",
-    )
-    stats_parser.add_argument("bucket", help="Bucket name")
-    stats_parser.add_argument("field", help="Field/column to analyze")
-    stats_parser.add_argument(
-        "prefix",
-        nargs="?",
-        default="",
-        help="Prefix path to scan (defaults to entire bucket)",
-    )
-
-    copy_parser = subparsers.add_parser(
-        "copy",
-        help="Copy a CSV object while removing a column",
-    )
-    copy_parser.add_argument("src_bucket", help="Source bucket")
-    copy_parser.add_argument("src_object", help="Source CSV object path")
-    copy_parser.add_argument("field", help="Field/column to remove")
-    copy_parser.add_argument("dest_object", help="Destination object path")
-    copy_parser.add_argument(
-        "--dest-bucket",
-        dest="dest_bucket",
-        help="Destination bucket (defaults to the source bucket)",
-    )
-
-    args = parser.parse_args()
+    if not parsed.command:
+        parser.print_help()
+        return
 
     if INSTALLED_PACKAGES:
         print(
@@ -544,13 +562,22 @@ def run_cli() -> None:
     if not config:
         return
 
+    bucket_default = config.get("bucket", "") or ""
+    prefix_default = config.get("prefix", "") or ""
 
     secure, ssl_config, http_client, cert_check = resolve_ssl_options(config)
+    scheme = "https" if secure else "http"
     conn_msg = (
-        f"Connecting to MinIO at {config['endpoint']} as {config['access_key']} "
-        f"(secure={secure}, cert_check={cert_check})"
+        f"Connecting to MinIO at {config['endpoint']} via {scheme.upper()} "
+        f"as {config['access_key']} (secure={secure}, cert_check={cert_check})"
     )
     print(conn_msg)
+    config_summary = (
+        f"Configured defaults -> secure={secure} ({scheme}), "
+        f"bucket={bucket_default or '(not set)'}, "
+        f"prefix={prefix_default or '(not set)'}"
+    )
+    print(config_summary)
     if config.get("ssl") is not None:
         print("SSL options:", format_ssl_display(ssl_config))
 
@@ -564,8 +591,40 @@ def run_cli() -> None:
         cert_check=cert_check,
     )
 
-    if args.command == "list":
-        results = list_csv_fields(client, args.bucket, args.prefix)
+    command_args = parsed.command_args
+
+    if parsed.command == "list":
+        list_parser = argparse.ArgumentParser(
+            prog=f"{prog_name} list",
+            description="List CSV files and show their fields.",
+        )
+        list_parser.add_argument(
+            "bucket",
+            nargs="?",
+            default=None,
+            help="Bucket name (defaults to the value from nocommit_minio.json)",
+        )
+        list_parser.add_argument(
+            "prefix",
+            nargs="?",
+            default=None,
+            help="Prefix path to scan (defaults to the value from nocommit_minio.json)",
+        )
+        list_args = list_parser.parse_args(command_args)
+        bucket = list_args.bucket if list_args.bucket not in (None, "") else bucket_default
+        prefix = (
+            list_args.prefix if list_args.prefix is not None else prefix_default
+        )
+        if not bucket:
+            print(
+                "Bucket must be provided either in nocommit_minio.json or as an argument."
+            )
+            return
+        prefix = prefix or ""
+        print(
+            f"Using bucket='{bucket}', prefix='{prefix or '(none)'}' for list command."
+        )
+        results = list_csv_fields(client, bucket, prefix)
         if results:
             for path, fields in results:
                 print(f"{path}: {', '.join(fields)}")
@@ -575,29 +634,113 @@ def run_cli() -> None:
             )
         else:
             print("No CSV files found for the provided bucket and prefix.")
-    elif args.command == "stats":
-        total, missing = field_stats(client, args.bucket, args.prefix, args.field)
+    elif parsed.command == "stats":
+        stats_parser = argparse.ArgumentParser(
+            prog=f"{prog_name} stats",
+            description="Show total rows and missing values for a field.",
+        )
+        stats_parser.add_argument(
+            "--bucket",
+            dest="bucket_option",
+            help="Override the bucket (defaults to the value from nocommit_minio.json)",
+        )
+        stats_parser.add_argument(
+            "--prefix",
+            dest="prefix_option",
+            help="Override the prefix (defaults to the value from nocommit_minio.json)",
+        )
+        stats_parser.add_argument(
+            "--field",
+            dest="field_option",
+            help="Field/column to analyze (alternative to positional argument)",
+        )
+        stats_parser.add_argument(
+            "positionals",
+            nargs="*",
+            help="Positional arguments: [bucket] field [prefix]",
+        )
+        stats_args = stats_parser.parse_args(command_args)
+
+        bucket = stats_args.bucket_option or bucket_default
+        prefix = (
+            stats_args.prefix_option
+            if stats_args.prefix_option is not None
+            else prefix_default
+        )
+        field = stats_args.field_option
+        positionals = stats_args.positionals
+
+        if positionals:
+            if len(positionals) == 1:
+                if stats_args.bucket_option is not None or bucket_default:
+                    field = field or positionals[0]
+                else:
+                    bucket = positionals[0]
+            elif len(positionals) == 2:
+                if stats_args.bucket_option is not None:
+                    field = field or positionals[0]
+                    if stats_args.prefix_option is None:
+                        prefix = positionals[1]
+                else:
+                    bucket = positionals[0]
+                    field = field or positionals[1]
+            else:
+                bucket = positionals[0]
+                field = field or positionals[1]
+                if stats_args.prefix_option is None:
+                    prefix = " ".join(positionals[2:])
+
+        if not bucket:
+            print(
+                "Bucket must be provided either in nocommit_minio.json or as an argument."
+            )
+            return
+        if not field:
+            print(
+                "Field name is required. Provide it as a positional argument or via --field."
+            )
+            return
+
+        prefix = prefix or ""
+        print(
+            f"Using bucket='{bucket}', prefix='{prefix or '(none)'}', field='{field}' for stats command."
+        )
+        total, missing = field_stats(client, bucket, prefix, field)
         print(f"Total rows: {total}")
         print(f"Missing values: {missing}")
         if total:
             print(f"Missing ratio: {missing / total:.2%}")
-    elif args.command == "copy":
+    elif parsed.command == "copy":
+        copy_parser = argparse.ArgumentParser(
+            prog=f"{prog_name} copy",
+            description="Copy a CSV object while removing a column.",
+        )
+        copy_parser.add_argument("src_bucket", help="Source bucket")
+        copy_parser.add_argument("src_object", help="Source CSV object path")
+        copy_parser.add_argument("field", help="Field/column to remove")
+        copy_parser.add_argument("dest_object", help="Destination object path")
+        copy_parser.add_argument(
+            "--dest-bucket",
+            dest="dest_bucket",
+            help="Destination bucket (defaults to the source bucket)",
+        )
+        copy_args = copy_parser.parse_args(command_args)
         try:
             original_fields, remaining_fields = copy_csv_without_field(
                 client,
-                args.src_bucket,
-                args.src_object,
-                args.field,
-                args.dest_object,
-                args.dest_bucket,
+                copy_args.src_bucket,
+                copy_args.src_object,
+                copy_args.field,
+                copy_args.dest_object,
+                copy_args.dest_bucket,
             )
         except ValueError as exc:
             print(f"Error: {exc}")
             return
         print(
             "Copied",
-            f"{args.src_bucket}/{args.src_object} -> {(args.dest_bucket or args.src_bucket)}/{args.dest_object}",
-            f"without field '{args.field}'",
+            f"{copy_args.src_bucket}/{copy_args.src_object} -> {(copy_args.dest_bucket or copy_args.src_bucket)}/{copy_args.dest_object}",
+            f"without field '{copy_args.field}'",
         )
         print("Original fields:", ", ".join(original_fields))
         print("Remaining fields:", ", ".join(remaining_fields))


### PR DESCRIPTION
## Summary
- sanitize optional bucket and prefix values when loading `nocommit_minio.json` and document the new defaults in the generated template
- surface the configured scheme, bucket, and prefix in the Streamlit app while pre-populating all bucket inputs with the parsed defaults
- overhaul the CLI to reuse the configuration defaults, expose the chosen connection details, and provide flexible argument parsing for list and stats commands

## Testing
- python -m compileall apps/minio/scan/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d1640625a883319d5946a982fb3e6f