### PR TITLE
Add shared RAG verification helpers

### DIFF
--- a/apps/deeplearning/LLM/5090/gemma/README.md
+++ b/apps/deeplearning/LLM/5090/gemma/README.md
@@ -119,3 +119,95 @@ Use the model verification helper against cached markdown files:
 ```bash
 python3 /Users/tinyos/devel_opment/BerePi/apps/deeplearning/LLM/5090/gemma/verify_model_rag_pipeline.py --cache-dir /Users/tinyos/devel_opment/BerePi/apps/nextcloud --question "How does clipboard markdown upload to Nextcloud work?"
 ```
+
+## 한글 안내
+
+이 앱은 `RTX 5090` 환경에서 `Streamlit` 과 `Ollama` 를 이용해 `gemma` 와 `qwen` 계열 모델을 함께 사용할 수 있도록 만든 인터페이스입니다. 기본 모델은 `gemma3:4b` 이며, 필요하면 사이드바에서 다른 모델을 선택하거나 직접 다운로드할 수 있습니다.
+
+### 주요 기능
+
+- 텍스트 질의응답
+- Excel 업로드 및 시트 미리보기
+- 이미지 업로드 및 모델 입력
+- `workspace` 내부 파일 다운로드 및 삭제
+- Nextcloud WebDAV 경로를 통한 Markdown/PDF 문서 RAG
+- `qwen2.5-coder:7b`, `qwen3-coder:30b` 선택 시 workspace tool calling 지원
+
+### 모델별 동작
+
+- `gemma` 계열 모델은 일반 질의응답 모드로 동작합니다.
+- `qwen coder` 계열 모델은 일반 질의응답에 더해 workspace 파일 도구를 사용할 수 있습니다.
+- WebDAV 에서 읽어온 RAG 문맥은 `gemma`, `qwen` 선택 모델 모두 공통으로 사용합니다.
+- 즉, 모델마다 답변 스타일이나 tool calling 가능 여부는 다를 수 있지만, 문서 검색 결과 자체는 같은 흐름으로 연결됩니다.
+
+### 설치 방법
+
+```bash
+cd /Users/tinyos/devel_opment/BerePi/apps/deeplearning/LLM/5090/gemma
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Ollama 준비
+
+먼저 `Ollama` 서버를 실행합니다.
+
+```bash
+ollama serve
+```
+
+기본 Gemma 모델을 다운로드합니다.
+
+```bash
+ollama pull gemma3:4b
+```
+
+코딩형 모델도 함께 쓰려면 아래 모델을 추가로 받을 수 있습니다.
+
+```bash
+ollama pull qwen2.5-coder:7b
+ollama pull qwen3-coder:30b
+```
+
+### 실행 방법
+
+```bash
+cd /Users/tinyos/devel_opment/BerePi/apps/deeplearning/LLM/5090/gemma
+chmod +x run.sh
+./run.sh
+```
+
+또는 직접 실행할 수 있습니다.
+
+```bash
+streamlit run app.py --server.address 0.0.0.0 --server.port 2280
+```
+
+### WebDAV / RAG 사용 방법
+
+- 오른쪽 `WebDAV / RAG` 패널에서 Nextcloud WebDAV 주소와 계정 정보를 설정합니다.
+- `Read Path 1` 부터 `Read Path 4` 까지 필요한 문서 경로를 입력할 수 있습니다.
+- 앱은 각 경로 아래의 `.md`, `.markdown`, `.pdf` 파일을 읽어서 간단한 lexical RAG 인덱스를 구성합니다.
+- 사용자가 질문하면 현재 질문과 관련성이 높은 문서 조각을 찾아 프롬프트에 함께 넣습니다.
+- 이 검색 문맥은 선택된 `gemma` 와 `qwen` 모델 모두에 공통으로 전달됩니다.
+
+### 저장 위치와 설정
+
+- 업로드된 Excel 파일은 `/Users/tinyos/devel_opment/BerePi/apps/deeplearning/LLM/5090/gemma/workspace` 에 저장됩니다.
+- 앱 설정은 `/Users/tinyos/devel_opment/BerePi/apps/deeplearning/LLM/5090/gemma/app_settings.json` 에 저장됩니다.
+- 모델 저장 경로를 바꿔도 실제 다운로드 위치를 바꾸려면 `Ollama` 를 `OLLAMA_MODELS` 환경변수와 함께 다시 시작해야 합니다.
+
+### 검증 방법
+
+공통 RAG 연결이 정상인지 테스트하려면 아래 단위 테스트를 실행합니다.
+
+```bash
+python3 -m unittest /Users/tinyos/devel_opment/BerePi/apps/deeplearning/LLM/5090/gemma/test_rag_pipeline.py
+```
+
+실제 Markdown 캐시를 기준으로 모델별 공통 RAG 연결 상태를 확인하려면 아래 스크립트를 실행합니다.
+
+```bash
+python3 /Users/tinyos/devel_opment/BerePi/apps/deeplearning/LLM/5090/gemma/verify_model_rag_pipeline.py --cache-dir /Users/tinyos/devel_opment/BerePi/apps/nextcloud --question "How does clipboard markdown upload to Nextcloud work?"
+```

--- a/apps/deeplearning/LLM/5090/gemma/README.md
+++ b/apps/deeplearning/LLM/5090/gemma/README.md
@@ -100,7 +100,22 @@ streamlit run app.py --server.address 0.0.0.0 --server.port 2280
 - The inferred storage path follows the local `OLLAMA_MODELS` setting or the default `~/.ollama/models` path.
 - Workspace file tools are limited to the app-local `workspace` directory for safety.
 - Qwen coder models run with workspace tool calling, while Gemma models stay in normal chat mode without workspace tool calling.
+- The same WebDAV RAG context is shared across the selectable Gemma and Qwen models; only tool-calling capability differs by model family.
 - When a user asks to download a workspace file, the tool-capable model can call `download_file` and the app shows a button in the `Workspace Downloads` section.
 - If a tool-capable model repeats the same tool call or reaches the tool round cap, the app now asks the model for a final non-tool answer instead of failing immediately.
 - Changing the model storage path in the app updates the desired location and can move existing files, but Ollama must be restarted with `OLLAMA_MODELS` set to the same path for future downloads to use it.
 - The selected model storage path is saved in `/Users/tinyos/devel_opment/BerePi/apps/deeplearning/LLM/5090/gemma/app_settings.json` and restored on the next app start.
+
+## Verify Shared RAG Wiring
+
+Use the unit test:
+
+```bash
+python3 -m unittest /Users/tinyos/devel_opment/BerePi/apps/deeplearning/LLM/5090/gemma/test_rag_pipeline.py
+```
+
+Use the model verification helper against cached markdown files:
+
+```bash
+python3 /Users/tinyos/devel_opment/BerePi/apps/deeplearning/LLM/5090/gemma/verify_model_rag_pipeline.py --cache-dir /Users/tinyos/devel_opment/BerePi/apps/nextcloud --question "How does clipboard markdown upload to Nextcloud work?"
+```

--- a/apps/deeplearning/LLM/5090/gemma/pipeline_common.py
+++ b/apps/deeplearning/LLM/5090/gemma/pipeline_common.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Iterable
+
+SUPPORTED_MODEL_OPTIONS = [
+    "gemma3:1b",
+    "gemma3:4b",
+    "gemma3:12b",
+    "gemma3:27b",
+    "qwen2.5-coder:7b",
+    "qwen3-coder:30b",
+]
+
+MODEL_MEMORY_GUIDE_GB = {
+    "gemma3:1b": 4,
+    "gemma3:4b": 8,
+    "gemma3:12b": 20,
+    "gemma3:27b": 40,
+    "qwen2.5-coder:7b": 8,
+    "qwen3-coder:30b": 20,
+}
+
+MODEL_DEFAULT_TEMPERATURES = {
+    "gemma3:1b": 0.7,
+    "gemma3:4b": 0.7,
+    "gemma3:12b": 0.6,
+    "gemma3:27b": 0.5,
+    "qwen2.5-coder:7b": 0.2,
+    "qwen3-coder:30b": 0.2,
+}
+
+
+def model_supports_tools(model: str) -> bool:
+    """Return whether the selected model should use tool calling."""
+    return model.startswith("qwen2.5-coder:") or model.startswith("qwen3-coder:")
+
+
+def build_user_message(
+    prompt: str,
+    excel_contexts: Iterable[str],
+    markdown_contexts: Iterable[str],
+    allow_tools: bool,
+    workspace_root: Path,
+) -> str:
+    """Build the final prompt content sent to the model."""
+    content_parts = [prompt.strip()]
+
+    normalized_markdown_contexts = [context.strip() for context in markdown_contexts if context.strip()]
+    if normalized_markdown_contexts:
+        content_parts.append(
+            "Relevant markdown context retrieved from the shared WebDAV RAG store is below. "
+            "Use it when it helps answer the request, and cite the source file names when useful.\n\n"
+            + "\n\n".join(normalized_markdown_contexts)
+        )
+
+    normalized_excel_contexts = [context.strip() for context in excel_contexts if context.strip()]
+    if normalized_excel_contexts:
+        content_parts.append(
+            "The user also uploaded Excel data. Use the workbook summaries below when relevant.\n\n"
+            + "\n\n".join(normalized_excel_contexts)
+        )
+
+    if allow_tools:
+        content_parts.append(
+            "You may use workspace tools when needed. "
+            "If the user asks to download a workspace file, call download_file for that file so the UI can expose a download button. "
+            f"The workspace root is: {workspace_root.resolve()}"
+        )
+
+    return "\n\n".join(part for part in content_parts if part)
+
+
+def summarize_tool_calls(tool_calls: list[dict]) -> str:
+    """Return a stable summary string for loop detection and diagnostics."""
+    summary_parts: list[str] = []
+    for tool_call in tool_calls:
+        function = tool_call.get("function", {})
+        tool_name = str(function.get("name", ""))
+        arguments = function.get("arguments", {})
+        summary_parts.append(f"{tool_name}:{arguments}")
+    return " | ".join(summary_parts)
+
+
+def tokenize_for_rag(text: str) -> list[str]:
+    """Tokenize text for light-weight retrieval scoring."""
+    return re.findall(r"[A-Za-z0-9_]{2,}", text.lower())

--- a/apps/deeplearning/LLM/5090/gemma/rag_webdav.py
+++ b/apps/deeplearning/LLM/5090/gemma/rag_webdav.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import configparser
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote
+import xml.etree.ElementTree as ET
+
+from pipeline_common import tokenize_for_rag
+
+PROPFIND_BODY = """<?xml version="1.0" encoding="utf-8" ?>
+<d:propfind xmlns:d="DAV:">
+  <d:prop>
+    <d:getlastmodified />
+    <d:getcontentlength />
+    <d:resourcetype />
+  </d:prop>
+</d:propfind>
+"""
+
+DAV_NAMESPACE = {"d": "DAV:"}
+
+
+@dataclass
+class WebDavSettings:
+    config_path: Path
+    section_name: str
+    hostname: str
+    root: str
+    username: str
+    password: str
+    verify_ssl: bool
+
+
+@dataclass
+class SyncedMarkdownFile:
+    remote_path: str
+    local_path: Path
+    size_bytes: int
+
+
+@dataclass
+class RetrievedChunk:
+    source: str
+    chunk_id: int
+    score: float
+    content: str
+
+
+def load_webdav_settings(config_path: Path, section_name: str = "target") -> WebDavSettings:
+    """Load WebDAV settings from an ini-style config file."""
+    parser = configparser.ConfigParser()
+    read_files = parser.read(config_path)
+    if not read_files:
+        raise FileNotFoundError(f"WebDAV config file not found: {config_path}")
+    if section_name not in parser:
+        raise KeyError(f"WebDAV config section not found: {section_name}")
+
+    section = parser[section_name]
+    settings_section = parser["settings"] if "settings" in parser else {}
+    hostname = section.get("webdav_hostname", "").strip().rstrip("/")
+    root = section.get("webdav_root", "").strip().strip("/")
+    username = section.get("username", "").strip()
+    password = section.get("password", "").strip()
+    verify_ssl = str(settings_section.get("verify_ssl", "true")).strip().lower() not in {"false", "0", "no"}
+
+    if not hostname or not root or not username or not password:
+        raise ValueError("WebDAV config is missing hostname, root, username, or password.")
+
+    return WebDavSettings(
+        config_path=config_path,
+        section_name=section_name,
+        hostname=hostname,
+        root=root,
+        username=username,
+        password=password,
+        verify_ssl=verify_ssl,
+    )
+
+
+def build_remote_url(settings: WebDavSettings, remote_path: str = "") -> str:
+    """Build a direct WebDAV URL for a remote path."""
+    normalized_path = remote_path.strip("/")
+    base = f"{settings.hostname}/{settings.root}"
+    if normalized_path:
+        return f"{base}/{normalized_path}"
+    return base
+
+
+def propfind_list(settings: WebDavSettings, remote_path: str = "", depth: int = 1) -> list[dict]:
+    """List WebDAV entries with PROPFIND depth 1."""
+    import requests
+
+    response = requests.request(
+        "PROPFIND",
+        build_remote_url(settings, remote_path),
+        data=PROPFIND_BODY,
+        headers={
+            "Depth": str(depth),
+            "Content-Type": "application/xml",
+        },
+        auth=(settings.username, settings.password),
+        timeout=60,
+        verify=settings.verify_ssl,
+    )
+    response.raise_for_status()
+
+    document = ET.fromstring(response.text)
+    entries: list[dict] = []
+    root_url_suffix = f"/{settings.root.strip('/')}"
+    current_path = remote_path.strip("/")
+
+    for response_node in document.findall("d:response", DAV_NAMESPACE):
+        href = response_node.findtext("d:href", default="", namespaces=DAV_NAMESPACE)
+        propstat = response_node.find("d:propstat", DAV_NAMESPACE)
+        if propstat is None:
+            continue
+        prop = propstat.find("d:prop", DAV_NAMESPACE)
+        if prop is None:
+            continue
+
+        resource_type = prop.find("d:resourcetype", DAV_NAMESPACE)
+        is_dir = resource_type is not None and resource_type.find("d:collection", DAV_NAMESPACE) is not None
+
+        decoded_href = unquote(href)
+        if root_url_suffix not in decoded_href:
+            continue
+        relative = decoded_href.split(root_url_suffix, maxsplit=1)[1].strip("/")
+        if relative == current_path:
+            continue
+
+        entries.append(
+            {
+                "path": relative,
+                "is_dir": is_dir,
+                "size_bytes": int(prop.findtext("d:getcontentlength", default="0", namespaces=DAV_NAMESPACE) or 0),
+            }
+        )
+
+    return entries
+
+
+def list_markdown_files(settings: WebDavSettings, remote_subdir: str = "") -> list[str]:
+    """Recursively list markdown files from a WebDAV directory."""
+    queue = [remote_subdir.strip("/")]
+    discovered: list[str] = []
+
+    while queue:
+        current = queue.pop(0)
+        for entry in propfind_list(settings, current, depth=1):
+            entry_path = str(entry["path"]).strip("/")
+            if entry.get("is_dir"):
+                queue.append(entry_path)
+                continue
+            lowered = entry_path.lower()
+            if lowered.endswith(".md") or lowered.endswith(".markdown"):
+                discovered.append(entry_path)
+
+    return sorted(dict.fromkeys(discovered))
+
+
+def download_markdown_file(settings: WebDavSettings, remote_path: str, destination: Path) -> SyncedMarkdownFile:
+    """Download one remote markdown file into the local cache."""
+    import requests
+
+    response = requests.get(
+        build_remote_url(settings, remote_path),
+        auth=(settings.username, settings.password),
+        timeout=120,
+        verify=settings.verify_ssl,
+    )
+    response.raise_for_status()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(response.content)
+    return SyncedMarkdownFile(
+        remote_path=remote_path,
+        local_path=destination,
+        size_bytes=len(response.content),
+    )
+
+
+def sync_markdown_directory(
+    settings: WebDavSettings,
+    local_root: Path,
+    remote_subdir: str = "",
+) -> list[SyncedMarkdownFile]:
+    """Sync markdown files from WebDAV into a local cache directory."""
+    synced_files: list[SyncedMarkdownFile] = []
+    for remote_path in list_markdown_files(settings, remote_subdir):
+        relative = Path(remote_path)
+        destination = local_root / relative
+        synced_files.append(download_markdown_file(settings, remote_path, destination))
+    return synced_files
+
+
+def read_local_markdown_files(local_root: Path) -> list[tuple[str, str]]:
+    """Load cached markdown files from the local sync directory."""
+    if not local_root.exists():
+        return []
+
+    documents: list[tuple[str, str]] = []
+    for path in sorted(local_root.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in {".md", ".markdown"}:
+            continue
+        documents.append((str(path.relative_to(local_root)), path.read_text(encoding="utf-8", errors="replace")))
+    return documents
+
+
+def chunk_markdown_text(text: str, chunk_size: int = 900, overlap: int = 180) -> list[str]:
+    """Split markdown into overlapping text chunks."""
+    normalized = text.replace("\r\n", "\n").strip()
+    if not normalized:
+        return []
+
+    chunks: list[str] = []
+    start = 0
+    text_length = len(normalized)
+    while start < text_length:
+        end = min(text_length, start + chunk_size)
+        chunk = normalized[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        if end >= text_length:
+            break
+        start = max(end - overlap, start + 1)
+    return chunks
+
+
+def retrieve_markdown_chunks(
+    question: str,
+    documents: list[tuple[str, str]],
+    max_chunks: int = 4,
+) -> list[RetrievedChunk]:
+    """Retrieve relevant markdown chunks using lightweight lexical scoring."""
+    question_tokens = tokenize_for_rag(question)
+    if not question_tokens:
+        return []
+
+    scored_chunks: list[RetrievedChunk] = []
+    question_token_set = set(question_tokens)
+
+    for source, content in documents:
+        for index, chunk in enumerate(chunk_markdown_text(content)):
+            chunk_tokens = tokenize_for_rag(chunk)
+            if not chunk_tokens:
+                continue
+            chunk_token_set = set(chunk_tokens)
+            overlap = question_token_set & chunk_token_set
+            if not overlap:
+                continue
+            score = float(len(overlap)) / float(max(len(question_token_set), 1))
+            phrase_bonus = 0.25 if question.lower() in chunk.lower() else 0.0
+            scored_chunks.append(
+                RetrievedChunk(
+                    source=source,
+                    chunk_id=index,
+                    score=score + phrase_bonus,
+                    content=chunk,
+                )
+            )
+
+    scored_chunks.sort(key=lambda item: (-item.score, item.source, item.chunk_id))
+    return scored_chunks[:max_chunks]
+
+
+def format_retrieved_contexts(chunks: list[RetrievedChunk]) -> list[str]:
+    """Format retrieved markdown chunks for prompt injection."""
+    formatted: list[str] = []
+    for chunk in chunks:
+        formatted.append(
+            "\n".join(
+                [
+                    f"[Markdown Source] {chunk.source}",
+                    f"[Chunk] {chunk.chunk_id}",
+                    f"[Score] {chunk.score:.3f}",
+                    chunk.content,
+                ]
+            )
+        )
+    return formatted

--- a/apps/deeplearning/LLM/5090/gemma/test_rag_pipeline.py
+++ b/apps/deeplearning/LLM/5090/gemma/test_rag_pipeline.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+import sys
+import unittest
+
+THIS_DIR = Path(__file__).resolve().parent
+if str(THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(THIS_DIR))
+
+from pipeline_common import SUPPORTED_MODEL_OPTIONS, build_user_message, model_supports_tools
+from rag_webdav import format_retrieved_contexts, read_local_markdown_files, retrieve_markdown_chunks
+
+
+class RagPipelineTests(unittest.TestCase):
+    def test_supported_models_all_receive_shared_markdown_context(self) -> None:
+        contexts = [
+            "[Markdown Source] notes/runbook.md\n[Chunk] 0\n[Score] 1.000\nBackup steps are listed here."
+        ]
+
+        for model in SUPPORTED_MODEL_OPTIONS:
+            prompt = build_user_message(
+                prompt="How do I restore the backup?",
+                excel_contexts=[],
+                markdown_contexts=contexts,
+                allow_tools=model_supports_tools(model),
+                workspace_root=Path("/tmp/workspace"),
+            )
+            self.assertIn("[Markdown Source] notes/runbook.md", prompt)
+
+    def test_qwen_coder_models_keep_tool_mode_while_gemma_does_not(self) -> None:
+        self.assertTrue(model_supports_tools("qwen2.5-coder:7b"))
+        self.assertTrue(model_supports_tools("qwen3-coder:30b"))
+        self.assertFalse(model_supports_tools("gemma3:4b"))
+
+    def test_markdown_retrieval_uses_cached_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            docs_dir = root / "notes"
+            docs_dir.mkdir(parents=True, exist_ok=True)
+            (docs_dir / "backup.md").write_text(
+                "# Backup\nUse rsync for backup.\nRestore requires manifest validation.\n",
+                encoding="utf-8",
+            )
+            (docs_dir / "other.md").write_text(
+                "# Other\nThis note covers unrelated camera settings.\n",
+                encoding="utf-8",
+            )
+
+            documents = read_local_markdown_files(root)
+            chunks = retrieve_markdown_chunks("restore backup manifest", documents, max_chunks=2)
+            contexts = format_retrieved_contexts(chunks)
+
+            self.assertTrue(contexts)
+            self.assertIn("backup.md", contexts[0])
+            self.assertIn("Restore requires manifest validation", contexts[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/deeplearning/LLM/5090/gemma/verify_model_rag_pipeline.py
+++ b/apps/deeplearning/LLM/5090/gemma/verify_model_rag_pipeline.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+THIS_DIR = Path(__file__).resolve().parent
+if str(THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(THIS_DIR))
+
+from pipeline_common import SUPPORTED_MODEL_OPTIONS, build_user_message, model_supports_tools
+from rag_webdav import format_retrieved_contexts, read_local_markdown_files, retrieve_markdown_chunks
+
+
+def check_installed_models(host: str) -> set[str]:
+    import requests
+
+    response = requests.get(f"{host.rstrip('/')}/api/tags", timeout=15)
+    response.raise_for_status()
+    data = response.json()
+    return {
+        model.get("name", "").strip()
+        for model in data.get("models", [])
+        if model.get("name", "").strip()
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify shared WebDAV Markdown RAG prompt wiring for every model.")
+    parser.add_argument("--cache-dir", default="workspace/webdav_markdown", help="Local markdown cache directory")
+    parser.add_argument("--host", default="", help="Optional Ollama host for installed-model checks")
+    parser.add_argument("--question", default="Summarize the markdown notes about backup and restore steps.")
+    args = parser.parse_args()
+
+    cache_dir = Path(args.cache_dir).expanduser()
+    documents = read_local_markdown_files(cache_dir)
+    if not documents:
+        print(f"No markdown documents found in cache: {cache_dir}", file=sys.stderr)
+        return 1
+
+    contexts = format_retrieved_contexts(retrieve_markdown_chunks(args.question, documents, max_chunks=3))
+    if not contexts:
+        print("Markdown cache exists but no chunk matched the verification question.", file=sys.stderr)
+        return 1
+
+    installed_models: set[str] = set()
+    if args.host:
+        try:
+            installed_models = check_installed_models(args.host)
+        except Exception as exc:
+            print(f"Ollama installed-model check failed: {exc}", file=sys.stderr)
+
+    print(f"Markdown cache: {cache_dir}")
+    print(f"Documents: {len(documents)}")
+    print(f"Retrieved contexts: {len(contexts)}")
+    print("")
+
+    failures = 0
+    for model in SUPPORTED_MODEL_OPTIONS:
+        prompt = build_user_message(
+            prompt=args.question,
+            excel_contexts=[],
+            markdown_contexts=contexts,
+            allow_tools=model_supports_tools(model),
+            workspace_root=Path(args.cache_dir).resolve().parent,
+        )
+        has_rag = "[Markdown Source]" in prompt
+        tool_mode = model_supports_tools(model)
+        installed = "yes" if model in installed_models else ("unknown" if not args.host else "no")
+        status = "OK" if has_rag else "FAIL"
+        if not has_rag:
+            failures += 1
+        print(
+            f"{status} model={model} shared_rag={has_rag} "
+            f"tool_mode={tool_mode} installed={installed}"
+        )
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add lightweight shared RAG helper modules for verification flows
- add unit tests that check shared markdown RAG prompt wiring across Gemma and Qwen model options
- add a verification script and README usage notes for validating model-specific RAG connectivity

## Verification
- python3 -m unittest apps/deeplearning/LLM/5090/gemma/test_rag_pipeline.py
- python3 apps/deeplearning/LLM/5090/gemma/verify_model_rag_pipeline.py --cache-dir apps/nextcloud --question "How does clipboard markdown upload to Nextcloud work?"