### PR TITLE
add-multi-format-text-extraction

### DIFF
--- a/apps/deeplearning/agent/read_mach/README.md
+++ b/apps/deeplearning/agent/read_mach/README.md
@@ -1,5 +1,50 @@
 # read_mach
 
+## 추가 문서 및 그림 입력
+
+모든 지원 형식의 통합 진입점은 `text_extract.py`입니다. `--input-file`을 생략하면
+`input`과 하위 디렉토리에서 PDF, DOCX, HWPX, JPG, PNG를 찾아 경로순으로 처리합니다.
+
+```powershell
+python .\text_extract.py
+```
+
+일부 파일만 순서대로 처리하려면 옵션을 여러 번 지정합니다.
+
+```powershell
+python .\text_extract.py `
+  --input-file ".\input\보고서.pdf" `
+  --input-file ".\input\문서.hwpx" `
+  --input-file ".\input\화면.png"
+```
+
+기본적으로 한 파일이 실패해도 다음 파일을 계속 처리합니다. 첫 실패에서 중단하려면
+`--fail-fast`를 사용합니다. PDF 전용 페이지 및 OCR 옵션도 통합 진입점에서 전달할 수
+있습니다.
+
+`input` 디렉토리 안의 DOCX, HWPX, JPG, PNG 파일도 각각의 실행 파일로 처리할 수 있습니다.
+DOCX/HWPX는 XML 본문을 직접 추출하고 문서에 포함된 PNG/JPEG 그림은 비전 모델 OCR로
+전사합니다. JPG/PNG는 그림 전체를 비전 모델로 전사합니다. 결과는 `output` 디렉토리에
+UTF-8 `.txt` 본문과 `.json` 메타데이터로 저장됩니다.
+
+```powershell
+python .\docx_text_extractor.py --input-file ".\input\문서.docx"
+python .\hwpx_text_extractor.py --input-file ".\input\문서.hwpx"
+python .\jpg_text_extractor.py  --input-file ".\input\사진.jpg"
+python .\png_text_extractor.py  --input-file ".\input\화면.png"
+```
+
+그림 OCR 또는 포함 그림 OCR이 필요한 경우 PDF 처리와 마찬가지로 서버 비밀번호를 먼저
+지정해야 합니다.
+
+```powershell
+$env:READ_MACH_PASSWORD = "<서버 비밀번호 입력>"
+```
+
+DOCX/HWPX에 텍스트만 있고 지원되는 포함 그림이 없으면 모델 서버를 호출하지 않습니다.
+현재 문서 내 포함 그림 OCR은 PNG, JPG/JPEG에 적용되며 EMF/WMF 같은 벡터 그림은
+건너뜁니다.
+
 ## PDF 문자 추출 모듈
 
 `pdf_text_extractor.py`는 PDF의 텍스트 레이어를 페이지별로 읽고, 문자가

--- a/apps/deeplearning/agent/read_mach/docx_text_extractor.py
+++ b/apps/deeplearning/agent/read_mach/docx_text_extractor.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Extract text and OCR embedded raster images from a DOCX document."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from pdf_text_extractor import normalize_extracted_text
+from vision_ocr_support import (
+    DEFAULT_CONFIG_PATH,
+    DEFAULT_OUTPUT_DIR,
+    OCR_PROMPT,
+    call_vision_ocr,
+    select_input_file,
+)
+
+WORD_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+RASTER_SUFFIXES = {".jpg", ".jpeg", ".png"}
+
+
+def extract_docx_package(path: Path) -> tuple[str, list[tuple[str, bytes]]]:
+    """Read visible document.xml text and supported images without Microsoft Word."""
+    try:
+        with zipfile.ZipFile(path) as archive:
+            root = ET.fromstring(archive.read("word/document.xml"))
+            blocks: list[str] = []
+            for paragraph in root.iter(f"{{{WORD_NS}}}p"):
+                value = "".join(node.text or "" for node in paragraph.iter(f"{{{WORD_NS}}}t")).strip()
+                if value:
+                    blocks.append(value)
+            images = [
+                (name, archive.read(name))
+                for name in archive.namelist()
+                if name.startswith("word/media/") and Path(name).suffix.casefold() in RASTER_SUFFIXES
+            ]
+    except (KeyError, zipfile.BadZipFile, ET.ParseError) as exc:
+        raise ValueError(f"올바른 DOCX 문서가 아닙니다: {path} | {exc}") from exc
+    return normalize_extracted_text("\n\n".join(blocks)), images
+
+
+def extract_docx_content(
+    path: Path, *, config_path: Path = DEFAULT_CONFIG_PATH, password: str | None = None
+) -> tuple[str, dict[str, object]]:
+    text, images = extract_docx_package(path)
+    ocr_blocks: list[str] = []
+    model_metadata: dict[str, object] = {"ocr_engine": "not-used", "ocr_model": None}
+    for index, (name, data) in enumerate(images, 1):
+        result, model_metadata = call_vision_ocr(
+            [data], f"{OCR_PROMPT}\nDOCX 포함 그림 {index}({name})를 전사한다.",
+            config_path=config_path, password=password, client_id="read-mach-docx-text-extractor",
+        )
+        if result.strip():
+            ocr_blocks.append(f"[DOCX embedded image {index}: {name}]\n{result.strip()}")
+    combined = "\n\n".join(part for part in [text, *ocr_blocks] if part).strip()
+    if not combined:
+        raise ValueError(f"DOCX에서 읽을 수 있는 문자나 지원되는 그림을 찾지 못했습니다: {path}")
+    metadata: dict[str, object] = {
+        "source_docx": str(path.resolve()), "format": "docx", "characters": len(combined),
+        "document_text_characters": len(text), "embedded_images": len(images),
+        "ocr_images": len(ocr_blocks), **model_metadata,
+    }
+    return combined, metadata
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="DOCX 문서의 본문과 포함 그림 문자를 추출합니다.")
+    parser.add_argument("--input-file", type=Path, required=True)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--password")
+    args = parser.parse_args()
+    try:
+        source = select_input_file(args.input_file, ".docx")
+        text, metadata = extract_docx_content(source, config_path=args.config, password=args.password)
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        text_path = args.output_dir / f"{source.stem}_docx_extracted.txt"
+        metadata_path = args.output_dir / f"{source.stem}_docx_extraction.json"
+        text_path.write_text(text + "\n", encoding="utf-8")
+        metadata_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        print(f"추출 문자 저장: {text_path}")
+        print(f"추출 정보 저장: {metadata_path}")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"DOCX 문자 추출 실패: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/deeplearning/agent/read_mach/hwpx_text_extractor.py
+++ b/apps/deeplearning/agent/read_mach/hwpx_text_extractor.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Extract text and OCR embedded raster images from an HWPX document."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from pdf_text_extractor import normalize_extracted_text
+from vision_ocr_support import (
+    DEFAULT_CONFIG_PATH,
+    DEFAULT_OUTPUT_DIR,
+    OCR_PROMPT,
+    call_vision_ocr,
+    select_input_file,
+)
+
+RASTER_SUFFIXES = {".jpg", ".jpeg", ".png"}
+
+
+def _section_number(name: str) -> tuple[int, str]:
+    match = re.search(r"section(\d+)\.xml$", name, flags=re.IGNORECASE)
+    return (int(match.group(1)) if match else 10**9, name)
+
+
+def extract_hwpx_package(path: Path) -> tuple[str, list[tuple[str, bytes]]]:
+    """Read HWPX section text and raster BinData entries using the standard library."""
+    try:
+        with zipfile.ZipFile(path) as archive:
+            section_names = sorted(
+                (name for name in archive.namelist() if re.search(r"(^|/)section\d+\.xml$", name, re.I)),
+                key=_section_number,
+            )
+            if not section_names:
+                raise ValueError("Contents/section*.xml 항목이 없습니다.")
+            blocks: list[str] = []
+            for section_name in section_names:
+                root = ET.fromstring(archive.read(section_name))
+                for node in root.iter():
+                    if node.tag.rsplit("}", 1)[-1] == "t" and node.text:
+                        value = node.text.strip()
+                        if value:
+                            blocks.append(value)
+            images = [
+                (name, archive.read(name))
+                for name in archive.namelist()
+                if name.casefold().startswith("bindata/") and Path(name).suffix.casefold() in RASTER_SUFFIXES
+            ]
+    except (zipfile.BadZipFile, ET.ParseError) as exc:
+        raise ValueError(f"올바른 HWPX 문서가 아닙니다: {path} | {exc}") from exc
+    return normalize_extracted_text("\n".join(blocks)), images
+
+
+def extract_hwpx_content(
+    path: Path, *, config_path: Path = DEFAULT_CONFIG_PATH, password: str | None = None
+) -> tuple[str, dict[str, object]]:
+    text, images = extract_hwpx_package(path)
+    ocr_blocks: list[str] = []
+    model_metadata: dict[str, object] = {"ocr_engine": "not-used", "ocr_model": None}
+    for index, (name, data) in enumerate(images, 1):
+        result, model_metadata = call_vision_ocr(
+            [data], f"{OCR_PROMPT}\nHWPX 포함 그림 {index}({name})를 전사한다.",
+            config_path=config_path, password=password, client_id="read-mach-hwpx-text-extractor",
+        )
+        if result.strip():
+            ocr_blocks.append(f"[HWPX embedded image {index}: {name}]\n{result.strip()}")
+    combined = "\n\n".join(part for part in [text, *ocr_blocks] if part).strip()
+    if not combined:
+        raise ValueError(f"HWPX에서 읽을 수 있는 문자나 지원되는 그림을 찾지 못했습니다: {path}")
+    metadata: dict[str, object] = {
+        "source_hwpx": str(path.resolve()), "format": "hwpx", "characters": len(combined),
+        "document_text_characters": len(text), "embedded_images": len(images),
+        "ocr_images": len(ocr_blocks), **model_metadata,
+    }
+    return combined, metadata
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="HWPX 문서의 본문과 포함 그림 문자를 추출합니다.")
+    parser.add_argument("--input-file", type=Path, required=True)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--password")
+    args = parser.parse_args()
+    try:
+        source = select_input_file(args.input_file, ".hwpx")
+        text, metadata = extract_hwpx_content(source, config_path=args.config, password=args.password)
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        text_path = args.output_dir / f"{source.stem}_hwpx_extracted.txt"
+        metadata_path = args.output_dir / f"{source.stem}_hwpx_extraction.json"
+        text_path.write_text(text + "\n", encoding="utf-8")
+        metadata_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        print(f"추출 문자 저장: {text_path}")
+        print(f"추출 정보 저장: {metadata_path}")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"HWPX 문자 추출 실패: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/deeplearning/agent/read_mach/image_text_extractor.py
+++ b/apps/deeplearning/agent/read_mach/image_text_extractor.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Common implementation used by the JPG and PNG command-line extractors."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from vision_ocr_support import (
+    DEFAULT_CONFIG_PATH,
+    DEFAULT_OUTPUT_DIR,
+    OCR_PROMPT,
+    call_vision_ocr,
+    image_mime_type,
+    select_input_file,
+)
+
+
+def extract_image_text(
+    image_path: Path, *, config_path: Path = DEFAULT_CONFIG_PATH, password: str | None = None
+) -> tuple[str, dict[str, object]]:
+    data = image_path.read_bytes()
+    image_mime_type(data)
+    text, model_metadata = call_vision_ocr([data], OCR_PROMPT, config_path=config_path, password=password)
+    metadata: dict[str, object] = {
+        "source_image": str(image_path.resolve()),
+        "format": image_path.suffix.lstrip(".").lower(),
+        "bytes": len(data),
+        "characters": len(text),
+        **model_metadata,
+    }
+    return text, metadata
+
+
+def run_image_cli(suffix: str, description: str) -> int:
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("--input-file", type=Path, required=True)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--password")
+    args = parser.parse_args()
+    try:
+        source = select_input_file(args.input_file, suffix)
+        text, metadata = extract_image_text(source, config_path=args.config, password=args.password)
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        stem = f"{source.stem}_{suffix.lstrip('.').lower()}_extracted"
+        text_path = args.output_dir / f"{stem}.txt"
+        metadata_path = args.output_dir / f"{stem}.json"
+        text_path.write_text(text + "\n", encoding="utf-8")
+        metadata_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        print(f"추출 문자 저장: {text_path}")
+        print(f"추출 정보 저장: {metadata_path}")
+        return 0
+    except Exception as exc:  # noqa: BLE001 - CLI must turn dependency/network errors into a clean exit
+        print(f"{suffix.upper()} 문자 추출 실패: {exc}", file=sys.stderr)
+        return 2

--- a/apps/deeplearning/agent/read_mach/jpg_text_extractor.py
+++ b/apps/deeplearning/agent/read_mach/jpg_text_extractor.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Extract text from one JPG image in input/."""
+
+from image_text_extractor import run_image_cli
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_image_cli(".jpg", "JPG 그림에서 문자를 추출합니다."))

--- a/apps/deeplearning/agent/read_mach/png_text_extractor.py
+++ b/apps/deeplearning/agent/read_mach/png_text_extractor.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Extract text from one PNG image in input/."""
+
+from image_text_extractor import run_image_cli
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_image_cli(".png", "PNG 그림에서 문자를 추출합니다."))

--- a/apps/deeplearning/agent/read_mach/test_document_text_extractors.py
+++ b/apps/deeplearning/agent/read_mach/test_document_text_extractors.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from docx_text_extractor import extract_docx_package
+from hwpx_text_extractor import extract_hwpx_package
+from vision_ocr_support import image_mime_type
+
+
+class DocumentTextExtractorTests(unittest.TestCase):
+    def test_extracts_docx_text_and_raster_images(self) -> None:
+        document = b'''<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:r><w:t>DOCX test</w:t></w:r></w:p></w:body>
+</w:document>'''
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "sample.docx"
+            with zipfile.ZipFile(path, "w") as archive:
+                archive.writestr("word/document.xml", document)
+                archive.writestr("word/media/image1.png", b"\x89PNG\r\n\x1a\ncontent")
+                archive.writestr("word/media/vector1.emf", b"ignored")
+            text, images = extract_docx_package(path)
+        self.assertEqual(text, "DOCX test")
+        self.assertEqual([name for name, _ in images], ["word/media/image1.png"])
+
+    def test_extracts_hwpx_sections_in_numeric_order(self) -> None:
+        section_one = b'<hp:section xmlns:hp="urn:hancom"><hp:p><hp:t>first</hp:t></hp:p></hp:section>'
+        section_two = b'<hp:section xmlns:hp="urn:hancom"><hp:p><hp:t>second</hp:t></hp:p></hp:section>'
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "sample.hwpx"
+            with zipfile.ZipFile(path, "w") as archive:
+                archive.writestr("Contents/section10.xml", section_two)
+                archive.writestr("Contents/section2.xml", section_one)
+                archive.writestr("BinData/image1.jpg", b"\xff\xd8\xffcontent")
+            text, images = extract_hwpx_package(path)
+        self.assertEqual(text, "first\nsecond")
+        self.assertEqual([name for name, _ in images], ["BinData/image1.jpg"])
+
+    def test_detects_supported_image_mime_types(self) -> None:
+        self.assertEqual(image_mime_type(b"\x89PNG\r\n\x1a\n"), "image/png")
+        self.assertEqual(image_mime_type(b"\xff\xd8\xff"), "image/jpeg")
+        with self.assertRaises(ValueError):
+            image_mime_type(b"not an image")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/deeplearning/agent/read_mach/test_text_extract.py
+++ b/apps/deeplearning/agent/read_mach/test_text_extract.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import text_extract
+
+
+class TextExtractDispatcherTests(unittest.TestCase):
+    def test_discovers_supported_files_in_stable_order(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "B.PNG").touch()
+            (root / "a.docx").touch()
+            (root / "ignored.txt").touch()
+            files = text_extract.discover_input_files(root)
+        self.assertEqual([path.name for path in files], ["a.docx", "B.PNG"])
+
+    def test_maps_each_extension_to_its_extractor(self) -> None:
+        for suffix, script_name in text_extract.EXTRACTORS.items():
+            with self.subTest(suffix=suffix), patch.object(text_extract.sys, "executable", "python"):
+                command = text_extract.extractor_command(
+                    Path(f"sample{suffix}"),
+                    config_path=Path("config.json"),
+                    output_dir=Path("output"),
+                    start_page=1,
+                    end_page=None,
+                    ocr_dpi=300,
+                    minimum_text_characters=100,
+                )
+            self.assertEqual(Path(command[1]).name, script_name)
+
+    def test_rejects_unsupported_explicit_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            unsupported = root / "notes.txt"
+            unsupported.touch()
+            with self.assertRaisesRegex(ValueError, "지원하지 않는"):
+                text_extract.resolve_requested_files(root, [unsupported])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/deeplearning/agent/read_mach/text_extract.py
+++ b/apps/deeplearning/agent/read_mach/text_extract.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Dispatch supported input files to the format-specific text extractors."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from vision_ocr_support import DEFAULT_CONFIG_PATH, DEFAULT_INPUT_DIR, DEFAULT_OUTPUT_DIR
+
+
+EXTRACTORS = {
+    ".pdf": "pdf_text_extractor.py",
+    ".docx": "docx_text_extractor.py",
+    ".hwpx": "hwpx_text_extractor.py",
+    ".jpg": "jpg_text_extractor.py",
+    ".png": "png_text_extractor.py",
+}
+
+
+def discover_input_files(input_dir: Path) -> list[Path]:
+    """Return all supported files below input_dir in deterministic path order."""
+    root = input_dir.expanduser().resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(f"입력 디렉토리가 없습니다: {root}")
+    return sorted(
+        (path for path in root.rglob("*") if path.is_file() and path.suffix.casefold() in EXTRACTORS),
+        key=lambda path: str(path).casefold(),
+    )
+
+
+def resolve_requested_files(input_dir: Path, requested_files: list[Path]) -> list[Path]:
+    """Resolve explicit files while keeping all access inside input_dir."""
+    root = input_dir.expanduser().resolve()
+    files: list[Path] = []
+    for requested in requested_files:
+        candidate = requested.expanduser().resolve()
+        selected = candidate if candidate.exists() else (root / requested).resolve()
+        try:
+            selected.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"--input-file은 input 디렉토리 내부 파일이어야 합니다: {selected}") from exc
+        if not selected.is_file():
+            raise FileNotFoundError(f"선택한 입력 파일이 없습니다: {selected}")
+        if selected.suffix.casefold() not in EXTRACTORS:
+            supported = ", ".join(sorted(EXTRACTORS))
+            raise ValueError(f"지원하지 않는 입력 형식입니다: {selected.suffix} (지원: {supported})")
+        files.append(selected)
+    return files
+
+
+def extractor_command(
+    source: Path,
+    *,
+    config_path: Path,
+    output_dir: Path,
+    start_page: int,
+    end_page: int | None,
+    ocr_dpi: int,
+    minimum_text_characters: int,
+) -> list[str]:
+    """Build the format-specific extractor command for one source file."""
+    suffix = source.suffix.casefold()
+    script = Path(__file__).resolve().parent / EXTRACTORS[suffix]
+    command = [
+        sys.executable,
+        str(script),
+        "--input-file",
+        str(source),
+        "--config",
+        str(config_path),
+        "--output-dir",
+        str(output_dir),
+    ]
+    if suffix == ".pdf":
+        command.extend(["--start-page", str(start_page), "--ocr-dpi", str(ocr_dpi)])
+        command.extend(["--minimum-text-characters", str(minimum_text_characters)])
+        if end_page is not None:
+            command.extend(["--end-page", str(end_page)])
+    return command
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="입력 파일 확장자에 맞는 추출기를 선택하여 문자를 순차 추출합니다."
+    )
+    parser.add_argument(
+        "--input-file",
+        type=Path,
+        action="append",
+        default=[],
+        help="처리할 input 내부 파일. 여러 번 지정 가능하며, 생략하면 지원 파일 전체를 처리합니다.",
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--start-page", type=int, default=1, help="PDF에만 적용")
+    parser.add_argument("--end-page", type=int, help="PDF에만 적용")
+    parser.add_argument("--ocr-dpi", type=int, default=300, help="PDF에만 적용")
+    parser.add_argument("--minimum-text-characters", type=int, default=100, help="PDF에만 적용")
+    parser.add_argument("--fail-fast", action="store_true", help="첫 실패에서 처리를 중단")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        sources = (
+            resolve_requested_files(DEFAULT_INPUT_DIR, args.input_file)
+            if args.input_file
+            else discover_input_files(DEFAULT_INPUT_DIR)
+        )
+    except (OSError, ValueError) as exc:
+        print(f"입력 파일 선택 실패: {exc}", file=sys.stderr)
+        return 2
+
+    if not sources:
+        print(f"지원되는 입력 파일이 없습니다: {DEFAULT_INPUT_DIR}", file=sys.stderr)
+        return 2
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    failures: list[tuple[Path, int]] = []
+    total = len(sources)
+    for index, source in enumerate(sources, 1):
+        extractor = EXTRACTORS[source.suffix.casefold()]
+        print(f"[{index}/{total}] {source.name} -> {extractor}", flush=True)
+        command = extractor_command(
+            source,
+            config_path=args.config,
+            output_dir=args.output_dir,
+            start_page=max(1, args.start_page),
+            end_page=args.end_page,
+            ocr_dpi=max(72, args.ocr_dpi),
+            minimum_text_characters=max(0, args.minimum_text_characters),
+        )
+        result = subprocess.run(command, check=False)
+        if result.returncode:
+            failures.append((source, result.returncode))
+            print(f"[{index}/{total}] 실패(exit={result.returncode}): {source}", file=sys.stderr)
+            if args.fail_fast:
+                break
+        else:
+            print(f"[{index}/{total}] 완료: {source.name}", flush=True)
+
+    completed = total - len(failures) if not args.fail_fast else index - len(failures)
+    print(f"처리 요약: 성공 {completed}, 실패 {len(failures)}, 대상 {total}")
+    if failures:
+        for source, returncode in failures:
+            print(f"- 실패(exit={returncode}): {source}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/deeplearning/agent/read_mach/vision_ocr_support.py
+++ b/apps/deeplearning/agent/read_mach/vision_ocr_support.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Shared input validation and vision-model OCR support for read_mach."""
+
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+from typing import Any
+
+
+APP_DIR = Path(__file__).resolve().parent
+DEFAULT_INPUT_DIR = APP_DIR / "input"
+DEFAULT_OUTPUT_DIR = APP_DIR / "output"
+DEFAULT_CONFIG_PATH = APP_DIR / "config" / "server_config.json"
+
+
+def select_input_file(input_file: Path, suffix: str) -> Path:
+    """Resolve one file below input/, rejecting traversal and wrong suffixes."""
+    input_dir = DEFAULT_INPUT_DIR.resolve()
+    requested = input_file.expanduser()
+    direct = requested.resolve()
+    selected = direct if direct.exists() else (input_dir / requested).resolve()
+    try:
+        selected.relative_to(input_dir)
+    except ValueError as exc:
+        raise ValueError(f"--input-file은 input 디렉토리 내부 파일이어야 합니다: {selected}") from exc
+    if not selected.is_file():
+        raise FileNotFoundError(f"선택한 입력 파일이 없습니다: {selected}")
+    if selected.suffix.casefold() != suffix.casefold():
+        raise ValueError(f"--input-file은 {suffix} 파일이어야 합니다: {selected}")
+    return selected
+
+
+def image_to_base64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def image_mime_type(data: bytes) -> str:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    raise ValueError("지원되는 PNG/JPEG 이미지 데이터가 아닙니다.")
+
+
+def call_vision_ocr(
+    images: list[bytes],
+    prompt: str,
+    *,
+    config_path: Path = DEFAULT_CONFIG_PATH,
+    password: str | None = None,
+    client_id: str = "read-mach-image-text-extractor",
+) -> tuple[str, dict[str, Any]]:
+    """Send one or more encoded images to the configured routing server."""
+    import requests
+
+    from extract_picture_pages import (
+        auth_headers,
+        load_server_config,
+        response_text,
+        select_ollama_target,
+    )
+
+    config = load_server_config(config_path)
+    password_env = str(config.get("password_env") or "READ_MACH_PASSWORD")
+    secret = password or os.getenv(password_env)
+    if not secret:
+        raise ValueError(f"서버 비밀번호가 없습니다. {password_env} 환경변수를 입력하세요.")
+    server_url = str(config.get("server_url") or "").rstrip("/")
+    if not server_url:
+        raise ValueError("설정 파일의 server_url이 비어 있습니다.")
+    timeout = int(config.get("timeout_seconds") or 240)
+    requested_model = str(config.get("model") or "")
+    explicit_target = str(config.get("target_id") or "") or None
+    encoded = [(image_to_base64(image), image_mime_type(image)) for image in images]
+
+    with requests.Session() as session:
+        target_id, model, api_type = select_ollama_target(
+            session,
+            server_url=server_url,
+            password=secret,
+            requested_model=requested_model,
+            explicit_target_id=explicit_target,
+        )
+        payload: dict[str, Any] = {
+            "client_id": client_id,
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "temperature": 0,
+            "timeout": timeout,
+            "target_id": target_id,
+        }
+        if api_type == "vllm":
+            payload["messages"] = [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    *[
+                        {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{item}"}}
+                        for item, mime in encoded
+                    ],
+                ],
+            }]
+        else:
+            payload["images"] = [item for item, _mime in encoded]
+        response = session.post(
+            f"{server_url}/api/generate",
+            headers=auth_headers(secret),
+            json=payload,
+            timeout=timeout + 30,
+        )
+        if not response.ok:
+            detail = response.text.strip().replace("\n", " ")[:500]
+            raise requests.HTTPError(
+                f"OCR 요청 실패: {response.status_code} {response.reason}: {detail}", response=response
+            )
+        text = response_text(response.json()).strip()
+        if not text:
+            raise ValueError("모델 OCR 응답이 비어 있습니다.")
+        return text, {"ocr_engine": "vision-model", "ocr_model": model, "target_id": target_id}
+
+
+OCR_PROMPT = """너는 기술문서 OCR 전사기다. 첨부 이미지를 읽고 보이는 문자를 정확히 전사해라.
+- 한국어와 영문 기술 용어를 원문 그대로 보존한다.
+- 제목, 본문, 표, 목록, 코드, 수식의 읽기 순서를 유지한다.
+- 표는 가능한 경우 Markdown 표로 변환한다.
+- 보이지 않는 내용은 추측하거나 설명하지 않는다.
+- 안내 문구와 코드 펜스 없이 추출된 본문만 출력한다.
+"""


### PR DESCRIPTION
## What changed

- Add format-specific text extractors for DOCX, HWPX, JPG, and PNG.
- Add shared vision OCR support for PNG/JPEG content.
- Add `text_extract.py` as a unified extension-based sequential dispatcher for PDF, DOCX, HWPX, JPG, and PNG.
- Document the new commands and add parser/dispatch tests.

## Why

`read_mach` previously accepted PDF files and web URLs only. This adds a single entry point for common document and image formats while retaining format-specific executables.

## Impact

Users can place supported files under `read_mach/input` and run `python text_extract.py` to process them sequentially. Text and metadata outputs continue to be written under `output`.

## Validation

- `python -m py_compile` for all new modules
- 14 relevant unit tests passed
- `git diff --check` passed
