### PR TITLE
add-multiple-url-extraction

### DIFF
--- a/apps/deeplearning/agent/read_mach/README.md
+++ b/apps/deeplearning/agent/read_mach/README.md
@@ -18,6 +18,20 @@ python .\text_extract.py `
   --input-file ".\input\화면.png"
 ```
 
+여러 웹페이지의 본문을 순차 추출하려면 `--url`을 반복 지정합니다. URL만 지정하면
+`input` 디렉토리의 파일은 자동 탐색하지 않습니다.
+
+```powershell
+python .\text_extract.py `
+  --url "https://example.com/article-1" `
+  --url "https://example.com/article-2" `
+  --url-timeout 60
+```
+
+`--input-file`과 `--url`을 함께 사용하면 지정한 로컬 파일을 먼저 처리한 뒤 URL을
+입력 순서대로 처리합니다. 각 URL 결과는 기존과 같이 `output`에 고유 해시가 포함된
+`.txt` 본문과 `.json` 메타데이터로 저장됩니다.
+
 기본적으로 한 파일이 실패해도 다음 파일을 계속 처리합니다. 첫 실패에서 중단하려면
 `--fail-fast`를 사용합니다. PDF 전용 페이지 및 OCR 옵션도 통합 진입점에서 전달할 수
 있습니다.

--- a/apps/deeplearning/agent/read_mach/test_text_extract.py
+++ b/apps/deeplearning/agent/read_mach/test_text_extract.py
@@ -40,6 +40,33 @@ class TextExtractDispatcherTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "지원하지 않는"):
                 text_extract.resolve_requested_files(root, [unsupported])
 
+    @patch.object(text_extract.sys, "executable", "python")
+    def test_builds_url_extractor_command(self) -> None:
+        command = text_extract.url_extractor_command(
+            "https://example.com/article",
+            config_path=Path("config.json"),
+            output_dir=Path("output"),
+            timeout=45,
+        )
+        self.assertEqual(Path(command[1]).name, "url_text_extractor.py")
+        self.assertEqual(command[command.index("--url") + 1], "https://example.com/article")
+        self.assertEqual(command[command.index("--timeout") + 1], "45")
+
+    @patch("text_extract.subprocess.run")
+    @patch("text_extract.parse_args")
+    def test_processes_multiple_urls_without_scanning_files(self, parse_args, run) -> None:
+        parse_args.return_value = type("Args", (), {
+            "input_file": [], "url": ["https://example.com/a", "https://example.com/b"],
+            "config": Path("config.json"), "output_dir": Path("output"),
+            "start_page": 1, "end_page": None, "ocr_dpi": 300,
+            "minimum_text_characters": 100, "url_timeout": 30, "fail_fast": False,
+        })()
+        run.return_value.returncode = 0
+        with patch.object(Path, "mkdir"):
+            result = text_extract.main()
+        self.assertEqual(result, 0)
+        self.assertEqual(run.call_count, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/apps/deeplearning/agent/read_mach/text_extract.py
+++ b/apps/deeplearning/agent/read_mach/text_extract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Dispatch supported input files to the format-specific text extractors."""
+"""Dispatch supported input files and URLs to their text extractors."""
 
 from __future__ import annotations
 
@@ -82,6 +82,25 @@ def extractor_command(
     return command
 
 
+def url_extractor_command(
+    url: str, *, config_path: Path, output_dir: Path, timeout: int
+) -> list[str]:
+    """Build the URL text extractor command for one web address."""
+    script = Path(__file__).resolve().parent / "url_text_extractor.py"
+    return [
+        sys.executable,
+        str(script),
+        "--url",
+        url,
+        "--config",
+        str(config_path),
+        "--output-dir",
+        str(output_dir),
+        "--timeout",
+        str(max(1, timeout)),
+    ]
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="입력 파일 확장자에 맞는 추출기를 선택하여 문자를 순차 추출합니다."
@@ -91,7 +110,16 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         action="append",
         default=[],
-        help="처리할 input 내부 파일. 여러 번 지정 가능하며, 생략하면 지원 파일 전체를 처리합니다.",
+        help=(
+            "처리할 input 내부 파일. 여러 번 지정 가능하며, 파일과 URL을 모두 생략하면 "
+            "지원 파일 전체를 처리합니다."
+        ),
+    )
+    parser.add_argument(
+        "--url",
+        action="append",
+        default=[],
+        help="본문을 추출할 HTTP/HTTPS URL. 여러 번 지정할 수 있습니다.",
     )
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
@@ -99,6 +127,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--end-page", type=int, help="PDF에만 적용")
     parser.add_argument("--ocr-dpi", type=int, default=300, help="PDF에만 적용")
     parser.add_argument("--minimum-text-characters", type=int, default=100, help="PDF에만 적용")
+    parser.add_argument("--url-timeout", type=int, default=30, help="URL별 요청 제한 시간(초)")
     parser.add_argument("--fail-fast", action="store_true", help="첫 실패에서 처리를 중단")
     return parser.parse_args()
 
@@ -106,48 +135,58 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     try:
-        sources = (
-            resolve_requested_files(DEFAULT_INPUT_DIR, args.input_file)
-            if args.input_file
-            else discover_input_files(DEFAULT_INPUT_DIR)
-        )
+        if args.input_file:
+            sources = resolve_requested_files(DEFAULT_INPUT_DIR, args.input_file)
+        elif args.url:
+            sources = []
+        else:
+            sources = discover_input_files(DEFAULT_INPUT_DIR)
     except (OSError, ValueError) as exc:
         print(f"입력 파일 선택 실패: {exc}", file=sys.stderr)
         return 2
 
-    if not sources:
-        print(f"지원되는 입력 파일이 없습니다: {DEFAULT_INPUT_DIR}", file=sys.stderr)
+    if not sources and not args.url:
+        print(f"지원되는 입력 파일 또는 URL이 없습니다: {DEFAULT_INPUT_DIR}", file=sys.stderr)
         return 2
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    failures: list[tuple[Path, int]] = []
-    total = len(sources)
-    for index, source in enumerate(sources, 1):
+    failures: list[tuple[str, int]] = []
+    tasks: list[tuple[str, str, list[str]]] = []
+    for source in sources:
         extractor = EXTRACTORS[source.suffix.casefold()]
-        print(f"[{index}/{total}] {source.name} -> {extractor}", flush=True)
         command = extractor_command(
-            source,
-            config_path=args.config,
-            output_dir=args.output_dir,
-            start_page=max(1, args.start_page),
-            end_page=args.end_page,
+            source, config_path=args.config, output_dir=args.output_dir,
+            start_page=max(1, args.start_page), end_page=args.end_page,
             ocr_dpi=max(72, args.ocr_dpi),
             minimum_text_characters=max(0, args.minimum_text_characters),
         )
+        tasks.append((str(source), extractor, command))
+    for url in args.url:
+        command = url_extractor_command(
+            url, config_path=args.config, output_dir=args.output_dir, timeout=args.url_timeout
+        )
+        tasks.append((url, "url_text_extractor.py", command))
+
+    total = len(tasks)
+    attempted = 0
+    successes = 0
+    for index, (label, extractor, command) in enumerate(tasks, 1):
+        attempted += 1
+        print(f"[{index}/{total}] {label} -> {extractor}", flush=True)
         result = subprocess.run(command, check=False)
         if result.returncode:
-            failures.append((source, result.returncode))
-            print(f"[{index}/{total}] 실패(exit={result.returncode}): {source}", file=sys.stderr)
+            failures.append((label, result.returncode))
+            print(f"[{index}/{total}] 실패(exit={result.returncode}): {label}", file=sys.stderr)
             if args.fail_fast:
                 break
         else:
-            print(f"[{index}/{total}] 완료: {source.name}", flush=True)
+            successes += 1
+            print(f"[{index}/{total}] 완료: {label}", flush=True)
 
-    completed = total - len(failures) if not args.fail_fast else index - len(failures)
-    print(f"처리 요약: 성공 {completed}, 실패 {len(failures)}, 대상 {total}")
+    print(f"처리 요약: 성공 {successes}, 실패 {len(failures)}, 시도 {attempted}, 대상 {total}")
     if failures:
-        for source, returncode in failures:
-            print(f"- 실패(exit={returncode}): {source}", file=sys.stderr)
+        for label, returncode in failures:
+            print(f"- 실패(exit={returncode}): {label}", file=sys.stderr)
         return 1
     return 0
 

--- a/git_basic.txt
+++ b/git_basic.txt
@@ -1,3 +1,4 @@
+
 # git for terminal use, configuration
 git config --list
 git config --unset --global credential.helper


### PR DESCRIPTION
## What changed

- Add repeatable `--url` arguments to the unified `text_extract.py` entry point.
- Process multiple web pages sequentially through `url_text_extractor.py`.
- Support mixed local-file and URL batches, URL request timeouts, fail-fast behavior, and aggregate summaries.
- Add dispatcher tests and usage documentation.

## Why

The unified extractor handled local files only, requiring users to invoke the URL extractor separately for every page.

## Impact

Users can now prepare text from multiple web pages with one command while receiving separate text and metadata outputs for each URL.

## Validation

- 16 relevant unit tests passed
- `python -m py_compile text_extract.py` passed
- `git diff --check` passed
